### PR TITLE
Superelliptical shape of corners

### DIFF
--- a/src/effect/rounded-corners-effect.ts
+++ b/src/effect/rounded-corners-effect.ts
@@ -22,6 +22,7 @@ const { declarations, code } = loadShader (
 class Uniforms {
     bounds = 0
     clip_radius = 0
+    smoothing = 0
     inner_bounds = 0
     inner_clip_radius = 0
     pixel_step = 0
@@ -54,6 +55,7 @@ export default registerClass (
             Effect.uniforms = {
                 bounds: 0,
                 clip_radius: 0,
+                smoothing: 0,
                 inner_bounds: 0,
                 inner_clip_radius: 0,
                 pixel_step: 0,
@@ -123,7 +125,7 @@ export default registerClass (
             const border_color = border.color
 
             const radius = corners_cfg.border_radius * scale_factor
-            const { padding } = corners_cfg
+            const { padding, smoothing } = corners_cfg
 
             const bounds = [
                 outer_bounds.x1 + padding.left * scale_factor,
@@ -152,6 +154,7 @@ export default registerClass (
             this.set_uniform_float (location.inner_bounds, 4, inner_bounds)
             this.set_uniform_float (location.pixel_step, 2, pixel_step)
             this.set_uniform_float (location.border_width, 1, [border_width])
+            this.set_uniform_float (location.smoothing, 1, [smoothing])
             this.set_uniform_float (location.clip_radius, 1, [radius])
             this.set_uniform_float (location.border_color, 4, border_color)
             this.set_uniform_float (location.inner_clip_radius, 1, [

--- a/src/manager/rounded-corners-manager.ts
+++ b/src/manager/rounded-corners-manager.ts
@@ -249,6 +249,11 @@ export class RoundedCornersManager {
         }
         const { left, right, top, bottom } = padding
 
+        // Increasing border_radius when smoothing is on
+        if (this.global_rounded_corners !== null) {
+            border_radius *= 1.0 + this.global_rounded_corners.smoothing
+        }
+
         // Sadly, the scale of style of St.Widget may be different between scale
         // of window if there are two monitor with different scale factor.
         // - Scale of Style always as same as primary monitor

--- a/src/preferences/widgets/rounded-corners-item.ts
+++ b/src/preferences/widgets/rounded-corners-item.ts
@@ -16,6 +16,7 @@ export default GObject.registerClass (
         InternalChildren: [
             'rounded_in_maximized_switch',
             'border_radius_scale',
+            'smoothing_scale',
             'padding_left_scale',
             'padding_right_scale',
             'padding_top_scale',
@@ -28,6 +29,7 @@ export default GObject.registerClass (
     class extends Gtk.ListBox {
         private _rounded_in_maximized_switch !: Gtk.Switch
         private _border_radius_scale         !: Gtk.Scale
+        private _smoothing_scale             !: Gtk.Scale
         private _padding_left_scale          !: Gtk.Scale
         private _padding_right_scale         !: Gtk.Scale
         private _padding_top_scale           !: Gtk.Scale
@@ -43,6 +45,7 @@ export default GObject.registerClass (
             super._init ()
             this._scales = [
                 this._border_radius_scale,
+                this._smoothing_scale,
                 this._padding_bottom_scale,
                 this._padding_left_scale,
                 this._padding_right_scale,
@@ -90,6 +93,7 @@ export default GObject.registerClass (
                 },
                 keep_rounded_corners: this._rounded_in_maximized_switch.active,
                 border_radius: this._border_radius_scale.get_value (),
+                smoothing: this._smoothing_scale.get_value (),
                 enabled: true,
             }
         }
@@ -97,6 +101,7 @@ export default GObject.registerClass (
         set cfg (cfg: RoundedCornersCfg) {
             this._rounded_in_maximized_switch.active = cfg.keep_rounded_corners
             this._border_radius_scale.set_value (cfg.border_radius)
+            this._smoothing_scale.set_value (cfg.smoothing)
             this._padding_left_scale.set_value (cfg.padding.left)
             this._padding_right_scale.set_value (cfg.padding.right)
             this._padding_top_scale.set_value (cfg.padding.top)

--- a/src/preferences/widgets/rounded-corners-item.ui
+++ b/src/preferences/widgets/rounded-corners-item.ui
@@ -39,6 +39,40 @@
     </child>
     <child>
       <object class="GtkListBoxRow">
+        <property name="name">Don't Configuration in Custom Page</property>
+        <child>
+          <object class="GtkBox">
+            <child>
+              <object class="GtkBox">
+                <property name="valign">center</property>
+                <property name="hexpand">true</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Corner Smoothing</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="smoothing_scale">
+                <property name="visible">true</property>
+                <property name="valign">center</property>
+                <property name="width-request">280</property>
+                <property name="draw-value">true</property>
+                <property name="round-digits">1</property>
+                <property name="orientation">horizontal</property>
+                <property name="adjustment">smoothing_ajustment</property>
+                <property name="value-pos">right</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkListBoxRow">
         <child>
           <object class="GtkBox">
             <child>
@@ -270,6 +304,12 @@
     <property name="upper">40</property>
     <property name="page-increment">1</property>
     <property name="step-increment">1</property>
+  </object>
+    <object class="GtkAdjustment" id="smoothing_ajustment">
+    <property name="lower">0</property>
+    <property name="upper">1</property>
+    <property name="page-increment">0.1</property>
+    <property name="step-increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="padding_left_ajustment">
     <property name="lower">0</property>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -17,6 +17,7 @@ export class Padding {
 export interface RoundedCornersCfg {
     keep_rounded_corners: boolean
     border_radius: number
+    smoothing: number
     padding: Padding
     enabled: boolean
 }


### PR DESCRIPTION
Implements #9
### Adds corner smoothing parameter
<video src="https://user-images.githubusercontent.com/63008755/182808401-293995ad-7081-486e-9350-00e034f6a367.webm" ></video>

Also radius always fits within the bounds, this was made to prevent overlapping because radius of smoothed corner is bigger than regular
<video src="https://user-images.githubusercontent.com/63008755/182810212-f4e67eac-4b71-42c6-84e6-928c72a02c40.webm" /></video>

