### PR TITLE
Fix wrong vfunc_pre_paint() in src/effect

### DIFF
--- a/src/effect/clip_shadow_effect.ts
+++ b/src/effect/clip_shadow_effect.ts
@@ -18,14 +18,12 @@ class ClipShadowEffect extends GLSLEffect {
         this.add_glsl_snippet (SnippetHook.FRAGMENT, declarations, code, false)
     }
 
-    vfunc_pre_paint (node: PaintNode, ctx: PaintContext): boolean {
-        const res = super.vfunc_pre_paint (node, ctx)
-
+    vfunc_paint_target (node: PaintNode, ctx: PaintContext) {
         // Reset to default blend string.
         this.get_pipeline ()?.set_blend (
             'RGBA = ADD(SRC_COLOR, DST_COLOR*(1-SRC_COLOR[A]))'
         )
-        return res
+        super.vfunc_paint_target (node, ctx)
     }
 }
 

--- a/src/effect/rounded-corners-effect.ts
+++ b/src/effect/rounded-corners-effect.ts
@@ -74,8 +74,7 @@ export default registerClass (
             this._init_uniforms ()
         }
 
-        vfunc_pre_paint (node: PaintNode, ctx: PaintContext): boolean {
-            const res = super.vfunc_pre_paint (node, ctx)
+        vfunc_paint_target (node: PaintNode, ctx: PaintContext) {
             this.get_pipeline ()?.set_layer_filters (
                 0,
                 PipelineFilter.LINEAR_MIPMAP_LINEAR,
@@ -100,7 +99,7 @@ export default registerClass (
             this.get_pipeline ()?.set_blend (
                 'RGBA = ADD(SRC_COLOR, DST_COLOR*(1-SRC_COLOR[A]))'
             )
-            return res
+            super.vfunc_paint_target (node, ctx)
         }
 
         /**


### PR DESCRIPTION
It is wrong to use vfunc_pre_paint() to setup pipeline, vfunc_paint_target() should be a right way.

Fix #15 

Now it should not occur memory spike when resizing window.

[录屏 2022年08月05日 00时34分00秒.webm](https://user-images.githubusercontent.com/32430186/182904741-57f09fa3-4fa0-4815-8ddd-d78665a12897.webm)

