### PR TITLE
Fix Overview broken when using together with Burn My Windows

### DIFF
--- a/@imports/ui/windowPreview.d.ts
+++ b/@imports/ui/windowPreview.d.ts
@@ -1,3 +1,6 @@
 import * as Shell from '../../@gi/Shell'
+import * as Meta from '../../@gi/Meta'
 
-export class WindowPreview extends Shell.WindowPreview { }
+export class WindowPreview extends Shell.WindowPreview {
+    _addWindow (_: Meta.Window): void;
+}

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -17,3 +17,16 @@ export const _logError = (err: Error) => {
     log (`[Rounded Corners Effect] Error occurs: ${err.message}`)
     logError (err)
 }
+
+/**
+ * Get stack message when called this function, this method
+ * will be used when monkey patch the code of gnome-shell to skip some
+ * function invocations.
+ */
+export const stackMsg = (): string | undefined => {
+    try {
+        throw Error ()
+    } catch (e) {
+        return (e as Error)?.stack?.trim ()
+    }
+}


### PR DESCRIPTION
imports.ui.workspace.Workspace._addWindowClone() has been patched in
`Burn My Windows`, it will break overview then this extensions enabled
with Burn My Windows

Now patch imports.ui.windowPreview.WindowPreview._addWindow() to add
shadow actor for windows in overview.

Fix #14