### PR TITLE
Allow different settings for rounding maximized & fullscreen windows

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
@@ -4,6 +4,10 @@
     id="org.gnome.shell.extensions.rounded-window-corners"
     path="/org/gnome/shell/extensions/rounded-window-corners/"
   >
+
+    <key name="settings-version" type="u">
+      <default>4</default>
+    </key>
     
     <key name="black-list" type="as">
       <default>["qq.exe", "tim.exe"]</default>
@@ -49,9 +53,12 @@
             'top': &lt;uint32 1&gt;,
             'bottom': &lt;uint32 1&gt;
           }&gt;,
-          'keep_rounded_corners': &lt;false&gt;,
+          'keep_rounded_corners': &lt;{
+            'maximized': &lt;false&gt;,
+            'fullscreen': &lt;false&gt;
+          }&gt;,
           'border_radius': &lt;uint32 12&gt;,
-          'smoothing': &lt;1.0&gt;
+          'smoothing': &lt;0.5&gt;
         }
       </default>
     </key>

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import { RestoreBackgroundMenu }       from './utils/ui'
 import { SetupBackgroundMenu }         from './utils/ui'
 import { WindowScaleFactor }           from './utils/ui'
 import { ChoiceRoundedCornersCfg }     from './utils/ui'
+import { ShouldHasRoundedCorners }     from './utils/ui'
 import Connections                     from './utils/connections'
 import settings                        from './utils/settings'
 import Services                        from './dbus/services'
@@ -126,11 +127,7 @@ export class Extension {
                     settings ().custom_rounded_corner_settings,
                     window
                 )
-                const maximized =
-                    window.maximized_horizontally ||
-                    window.maximized_vertically ||
-                    window.fullscreen
-                has_rounded_corners = cfg.keep_rounded_corners || !maximized
+                has_rounded_corners = ShouldHasRoundedCorners (window, cfg)
             }
             if (shadow && has_rounded_corners) {
                 const source = shadow

--- a/src/manager/rounded-corners-manager.ts
+++ b/src/manager/rounded-corners-manager.ts
@@ -653,21 +653,6 @@ export class RoundedCornersManager {
         this._update_all_shadow_actor_style ()
     }
 
-    /** Skip effect window is maximized */
-    private _setup_effect_skip_property (
-        keep_rounded_corners: boolean,
-        win: Window,
-        effect: RoundedCornersEffectType
-    ): boolean {
-        const maximized =
-            win.maximized_horizontally ||
-            win.maximized_vertically ||
-            win.fullscreen
-        const skip = !keep_rounded_corners && maximized
-        effect.skip = skip
-        return skip
-    }
-
     // ------------------------------------------------------- [signal handlers]
 
     /**
@@ -719,13 +704,12 @@ export class RoundedCornersManager {
 
             const cfg = this._get_rounded_corners_cfg (win)
 
-            // Skip rounded corners when
-            // window is maximized & 'Keep Rounded Corners' matched to disabled
-            this._setup_effect_skip_property (
-                cfg.keep_rounded_corners,
-                win,
-                effect
-            )
+            // Skip rounded corners when window is fullscreen & maximize
+            const skip = !UI.ShouldHasRoundedCorners (win, cfg)
+            effect.skip = skip
+            if (skip) {
+                return
+            }
             effect.update_uniforms (
                 UI.WindowScaleFactor (win),
                 cfg,

--- a/src/preferences/widgets/rounded-corners-item.ui
+++ b/src/preferences/widgets/rounded-corners-item.ui
@@ -83,7 +83,7 @@
                 <child>
                   <object class="GtkLabel">
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Keep Rounded Corners When Maximized</property>
+                    <property name="label" translatable="yes">Keep Rounded Corners when Maximized</property>
                   </object>
                 </child>
                 <child>
@@ -100,6 +100,43 @@
             </child>
             <child>
               <object class="GtkSwitch" id="rounded_in_maximized_switch">
+                <property name="visible">true</property>
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkListBoxRow">
+        <child>
+          <object class="GtkBox">
+            <child>
+              <object class="GtkBox">
+                <property name="valign">center</property>
+                <property name="hexpand">true</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Keep Rounded Corners when Fullscreen</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="halign">start</property>
+                    <property name="use-markup">true</property>
+                    <property name="label" translatable="yes">Always keep rounded corners when window is fullscreen.</property>
+                    <style>
+                      <class name="caption" />
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="rounded_in_fullscreen_switch">
                 <property name="visible">true</property>
                 <property name="valign">center</property>
               </object>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -15,7 +15,10 @@ export class Padding {
 
 /** Store into settings, rounded corners configuration  */
 export interface RoundedCornersCfg {
-    keep_rounded_corners: boolean
+    keep_rounded_corners: {
+        maximized: boolean
+        fullscreen: boolean
+    }
     border_radius: number
     smoothing: number
     padding: Padding

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -169,3 +169,24 @@ export const ChoiceRoundedCornersCfg = (
     custom_cfg.border_radius = global_cfg.border_radius
     return custom_cfg
 }
+
+/**
+ * Decide whether windows should have rounded corners when it has been
+ * maximized & fullscreen according to RoundedCornersCfg
+ */
+export function ShouldHasRoundedCorners (
+    win: Meta.Window,
+    cfg: types.RoundedCornersCfg
+): boolean {
+    let should_has_rounded_corners = false
+
+    const maximized = win.maximized_horizontally || win.maximized_vertically
+    const fullscreen = win.fullscreen
+
+    should_has_rounded_corners =
+        (!maximized && !fullscreen) ||
+        (maximized && cfg.keep_rounded_corners.maximized) ||
+        (fullscreen && cfg.keep_rounded_corners.fullscreen)
+
+    return should_has_rounded_corners
+}


### PR DESCRIPTION
Add new settings item in preferences page to skip / keep rounded corners for fullscreen windows.

Closes #10

https://user-images.githubusercontent.com/32430186/183245996-33b06703-d86d-4864-8a08-c452f1178fcc.mp4


