### PR TITLE
Clear all signal handlers when gnome-shell is shutdown

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -238,6 +238,16 @@ export class Extension {
             AddBackgroundMenuItem (actor._backgroundMenu)
         }
 
+        // Gnome-shell will not disable extensions when logout/shutdown/restart
+        // system, it means that the signal handlers will not be cleaned when
+        // gnome-shell is closing.
+        //
+        // Now clear all resources manually before gnome-shell closes
+        Connections.get ().connect (global.display, 'closing', () => {
+            log ('Clear all resources because gnome-shell is shutdown')
+            this.disable ()
+        })
+
         log ('Enabled')
     }
 

--- a/src/manager/rounded-corners-manager.ts
+++ b/src/manager/rounded-corners-manager.ts
@@ -74,7 +74,9 @@ export class RoundedCornersManager {
         const wm = global.window_manager
 
         // Try to add rounded corners effect to all windows
-        for (const actor of global.get_window_actors ()) {
+        const window_actors = global.get_window_actors ()
+        _log (`Windows count when enable: ${window_actors.length}`)
+        for (const actor of window_actors) {
             this._add_effect (actor)
         }
 


### PR DESCRIPTION
`disable ()` of extensions will not be called when logout/restart gnome-shell, it means that event handlers registered by this extensions will not be cleaned when window is disposed. Now clear all resources manually when gnome-shell is shutdown / restart.

Fix #26