### PR TITLE
Reset prefs dialog & Default shadow style

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
@@ -6,7 +6,7 @@
   >
     
     <key name="black-list" type="as">
-      <default>["qq.exe", "tim.exe"]</default>
+      <default>[]</default>
       <summary>window here will not be rounded</summary>
       <description>
         The contents of the list represent the instance part of the window's

--- a/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
@@ -67,10 +67,10 @@
       <default>
         {
           'horizontal_offset': 0,
-          'vertical_offset': 41,
-          'blur_offset': 38,
-          'spread_radius': -15,
-          'opacity': 53
+          'vertical_offset': 4,
+          'blur_offset': 28,
+          'spread_radius': 4,
+          'opacity': 60
         }
       </default>
     </key>
@@ -80,10 +80,10 @@
       <default>
         {
           'horizontal_offset': 0,
-          'vertical_offset': 10,
-          'blur_offset': 9,
-          'spread_radius': -5,
-          'opacity': 62
+          'vertical_offset': 2,
+          'blur_offset': 12,
+          'spread_radius': -1,
+          'opacity': 65
         }
       </default>
     </key>

--- a/resources/stylesheet-prefs.css
+++ b/resources/stylesheet-prefs.css
@@ -10,3 +10,15 @@
 .rotated {
     transform: rotate(90deg);
 }
+
+.dialog-vbox {
+    padding: 48px;
+}
+
+.dialog-vbox .heading {
+    padding-bottom: 24px;
+}
+
+.dialog-vbox checkbutton {
+    padding-right: 12px;
+}

--- a/src/manager/rounded-corners-manager.ts
+++ b/src/manager/rounded-corners-manager.ts
@@ -257,7 +257,14 @@ export class RoundedCornersManager {
         })
         ;(shadow.first_child as Bin).add_style_class_name ('shadow')
 
-        this._update_shadow_actor_style (actor.meta_window, shadow)
+        this._update_shadow_actor_style (
+            actor.meta_window,
+            shadow,
+            this.global_rounded_corners?.border_radius,
+            actor.meta_window.appears_focused
+                ? settings ().focused_shadow
+                : settings ().unfocused_shadow
+        )
 
         // We have to clip the shadow because of this issues:
         // https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/4474
@@ -427,6 +434,7 @@ export class RoundedCornersManager {
 
             // Update shadows and rounded corners bounds
             this.on_size_changed (actor)
+            this._on_focus_changed (actor.meta_window)
 
             // Connect signals of window, those signals will be disconnected
             // when window is destroyed

--- a/src/preferences/pages/general.ts
+++ b/src/preferences/pages/general.ts
@@ -11,6 +11,7 @@ import { template_url }    from '../../utils/io'
 import { _log }            from '../../utils/log'
 import RoundedCornersItems from '../widgets/rounded-corners-item'
 import EditShadowWindow    from '../widgets/edit-shadow-window'
+import ResetDialog         from '../widgets/reset-dialog'
 
 // types
 import * as Gtk            from '@gi/Gtk'
@@ -32,6 +33,7 @@ export default GObject.registerClass (
             'border_color_button',
             'edit_shadow_row',
             'applications_group',
+            'reset_preferences_btn',
         ],
     },
     class extends Gtk.Box {
@@ -44,6 +46,7 @@ export default GObject.registerClass (
         private _border_color_button               !: Gtk.ColorButton
         private _edit_shadow_row                   !: Gtk.ListBoxRow
         private _applications_group                !: Gtk.ListBox
+        private _reset_preferences_btn             !: Gtk.Button
 
         private config_items                       !: _Items
         private edit_shadow_window                 !: _Win
@@ -125,6 +128,12 @@ export default GObject.registerClass (
                         }
                     }
                 )
+
+            connections
+                .get ()
+                .connect (this._reset_preferences_btn, 'clicked', () => {
+                    new ResetDialog ().show ()
+                })
         }
 
         vfunc_root (): void {

--- a/src/preferences/pages/general.ts
+++ b/src/preferences/pages/general.ts
@@ -5,6 +5,7 @@ import * as Gio            from '@gi/Gio'
 
 // local modules
 import settings            from '../../utils/settings'
+import { SchemasKeys }     from '../../utils/settings'
 import connections         from '../../utils/connections'
 import { list_children }   from '../../utils/prefs'
 import { template_url }    from '../../utils/io'
@@ -49,15 +50,22 @@ export default GObject.registerClass (
         private _reset_preferences_btn             !: Gtk.Button
 
         private config_items                       !: _Items
-        private edit_shadow_window                 !: _Win
 
         _init () {
             super._init ()
 
-            this.edit_shadow_window = new EditShadowWindow ()
             this.config_items = new RoundedCornersItems ()
 
             this.build_ui ()
+
+            connections
+                .get ()
+                .connect (
+                    settings ().g_settings,
+                    'changed',
+                    (settings: Gio.Settings, key: string) =>
+                        this._on_settings_changed (key)
+                )
 
             settings ().bind (
                 'debug-mode',
@@ -164,17 +172,42 @@ export default GObject.registerClass (
 
         /** Called when click 'Window Shadow' action row */
         _show_edit_shadow_window_cb () {
-            const win = this.root as Gtk.Window
-            this.edit_shadow_window.application = win.application
-            this.edit_shadow_window.present ()
-            win.hide ()
-            this.edit_shadow_window.connect ('close-request', () => {
-                win.show ()
-                this.edit_shadow_window.hide ()
+            const root = this.root as Gtk.Window
+            const win = new EditShadowWindow ()
+            win.application = root.application
+            win.present ()
+            root.hide ()
+            win.connect ('close-request', () => {
+                root.show ()
+                win.destroy ()
             })
+        }
+
+        /** Update UI when settings changed  */
+        private _on_settings_changed (key: string) {
+            switch (key as SchemasKeys) {
+            case 'border-color':
+                {
+                    const color = settings ().border_color
+                    this._border_color_button.rgba = new Gdk.RGBA ({
+                        red: color[0],
+                        green: color[1],
+                        blue: color[2],
+                        alpha: color[3],
+                    })
+                }
+                break
+            case 'border-width':
+                this._border_width_ajustment.value = settings ().border_width
+                break
+            case 'global-rounded-corner-settings':
+                this.config_items.cfg =
+                        settings ().global_rounded_corner_settings
+                break
+            default:
+            }
         }
     }
 )
 
 type _Items = InstanceType<typeof RoundedCornersItems>
-type _Win = InstanceType<typeof EditShadowWindow>

--- a/src/preferences/pages/general.ui
+++ b/src/preferences/pages/general.ui
@@ -271,6 +271,24 @@
         </child>
       </object>
     </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Reset Preferences</property>
+        <style>
+          <class name="heading" />
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="reset_preferences_btn">
+        <property name="label">Reset Preferences</property>
+        <property name="halign">start</property>
+        <style>
+          <class name="destructive-action"/>
+        </style>
+      </object>
+    </child>
   </template>
 
   <object class="GtkAdjustment" id="border_width_ajustment">

--- a/src/preferences/widgets/edit-shadow-window.ts
+++ b/src/preferences/widgets/edit-shadow-window.ts
@@ -147,10 +147,6 @@ export default registerClass (
 
         // signal handles
 
-        _hide_window_cb () {
-            this.hide ()
-        }
-
         on_value_changed () {
             this.update_cfg ()
             this.update_style ()

--- a/src/preferences/widgets/reset-dialog.ts
+++ b/src/preferences/widgets/reset-dialog.ts
@@ -1,0 +1,168 @@
+import * as GObject              from '@gi/GObject'
+import * as Gtk                  from '@gi/Gtk'
+import { _log }                  from '../../utils/log'
+import settings, { SchemasKeys } from '../../utils/settings'
+import { RoundedCornersCfg }     from '../../utils/types'
+
+class Cfg {
+    description: string
+    reset = false
+
+    constructor (description: string) {
+        this.description = description
+    }
+}
+
+export default GObject.registerClass (
+    {},
+    class extends Gtk.Dialog {
+        /** Keys to reset  */
+        private _reset_keys        !: {
+            [name in SchemasKeys]?: Cfg
+        }
+        /** Global rounded corners settings to reset  */
+        private _reset_corners_cfg !: {
+            [name in keyof RoundedCornersCfg]?: Cfg
+        }
+        /** Used to select all CheckButtons  */
+        private _all_check_btns    !: Gtk.CheckButton[]
+
+        _init (): void {
+            super._init ({
+                use_header_bar: 1,
+                modal: true,
+                title: 'Reset Preferences',
+            })
+
+            this._all_check_btns = []
+
+            this.set_modal (true)
+
+            this.add_button ('Apply', Gtk.ResponseType.APPLY)
+            this.add_button ('Cancel', Gtk.ResponseType.CANCEL)
+
+            this.connect ('response', (source, id) => {
+                if (id === Gtk.ResponseType.CANCEL) {
+                    this.destroy ()
+                }
+                if (id === Gtk.ResponseType.APPLY) {
+                    this.apply ()
+                }
+            })
+
+            this._init_cfg ()
+            this._build_ui ()
+        }
+
+        private _init_cfg () {
+            this._reset_keys = {
+                'skip-libadwaita-app': new Cfg ('Skip LibAdwaita Applications'),
+                'skip-libhandy-app': new Cfg ('Skip LibHandy Applications'),
+                'focused-shadow': new Cfg ('Focus Window Shadow Style'),
+                'unfocused-shadow': new Cfg ('Unfocus Window Shadow Style'),
+                'border-width': new Cfg ('Border Width'),
+                'border-color': new Cfg ('Border Color'),
+                'debug-mode': new Cfg ('Enable Log'),
+            }
+
+            this._reset_corners_cfg = {
+                border_radius: new Cfg ('Border Radius'),
+                padding: new Cfg ('Padding'),
+                keep_rounded_corners: new Cfg (
+                    'Keep Rounded Corners when Maximized or Fullscreen'
+                ),
+                smoothing: new Cfg ('Corner Smoothing'),
+            }
+        }
+
+        private _build_ui () {
+            const content = this.get_content_area ()
+            content.orientation = Gtk.Orientation.VERTICAL
+            content.spacing = 8
+
+            // Title
+            content.append (
+                new Gtk.Label ({
+                    label: 'Select Items to reset',
+                    css_classes: ['heading'],
+                    halign: Gtk.Align.START,
+                })
+            )
+
+            // Select All Checkbox
+            const select_all_check_btn = new Gtk.CheckButton ()
+            const select_all_label = new Gtk.Label ({
+                label: 'Select All',
+            })
+            const row = new Gtk.Box ()
+            row.append (select_all_check_btn)
+            row.append (select_all_label)
+            content.append (row)
+
+            select_all_check_btn.connect ('toggled', (btn) => {
+                this._all_check_btns.forEach ((b) => (b.active = btn.active))
+            })
+
+            const build = (cfg: { [key: string]: { description: string } }) => {
+                Object.keys (cfg).forEach ((key) => {
+                    const item = new Gtk.Box ()
+                    const check_btn = new Gtk.CheckButton ({
+                        active: false,
+                        name: key,
+                    })
+                    check_btn.connect ('toggled', (source) =>
+                        this.on_toggled (source)
+                    )
+                    item.append (check_btn)
+                    item.append (Gtk.Label.new (cfg[key].description))
+                    content.append (item)
+
+                    this._all_check_btns.push (check_btn)
+                })
+            }
+
+            build (this._reset_corners_cfg)
+            build (this._reset_keys)
+        }
+
+        private on_toggled (source: Gtk.CheckButton): void {
+            const k = source.name
+            let v = this._reset_corners_cfg[k as keyof RoundedCornersCfg]
+            if (v !== undefined) {
+                v.reset = source.active
+                return
+            }
+
+            v = this._reset_keys[k as SchemasKeys]
+            if (v !== undefined) {
+                v.reset = source.active
+                return
+            }
+        }
+
+        private apply () {
+            for (const k of Object.keys (this._reset_keys)) {
+                if (this._reset_keys[k as SchemasKeys]?.reset === true) {
+                    settings ().g_settings.reset (k)
+                    _log ('Reset ' + k)
+                }
+            }
+
+            const key: SchemasKeys = 'global-rounded-corner-settings'
+            const default_cfg = settings ()
+                .g_settings.get_default_value (key)
+                ?.recursiveUnpack () as RoundedCornersCfg
+            const current_cfg = settings ().global_rounded_corner_settings
+            for (const k of Object.keys (this._reset_corners_cfg)) {
+                const _k = k as keyof RoundedCornersCfg
+                if (this._reset_corners_cfg[_k]?.reset === true) {
+                    current_cfg[_k] = default_cfg[_k] as never
+                    _log ('Reset ' + k)
+                }
+            }
+            settings ().global_rounded_corner_settings = current_cfg
+
+            this.destroy ()
+        }
+    }
+)


### PR DESCRIPTION
Add a simple reset dialog to reset settings in `General` page:

![image](https://user-images.githubusercontent.com/32430186/183304334-a9c217af-299a-4598-bcaf-5c5f3f9e8c67.png)

Closes #11, Closes #12 
