### PR TITLE
Remove 'skip' uniform variable in rounded corners shader

### DIFF
--- a/src/effect/rounded_corners_effect.ts
+++ b/src/effect/rounded_corners_effect.ts
@@ -24,7 +24,6 @@ class Uniforms {
     inner_bounds = 0
     inner_clip_radius = 0
     pixel_step = 0
-    skip = 0
     border_width = 0
     border_color = 0
 }
@@ -40,12 +39,6 @@ export const RoundedCornersEffect = registerClass (
         static uniforms: Uniforms = new Uniforms ()
 
         /**
-         * Wether skip rounded corners effect, its useful to disable rounded
-         * corners when window is maximized
-         */
-        private _skip = false
-
-        /**
          * Collect location of uniform variants, only used when added shader
          * snippet to effect.
          */
@@ -57,7 +50,6 @@ export const RoundedCornersEffect = registerClass (
                 inner_bounds: 0,
                 inner_clip_radius: 0,
                 pixel_step: 0,
-                skip: 0,
                 border_width: 0,
                 border_color: 0,
             }
@@ -116,7 +108,6 @@ export const RoundedCornersEffect = registerClass (
             }
 
             const pixel_step = [1 / actor.get_width (), 1 / actor.get_height ()]
-            const _skip = this._skip ? 1 : 0
 
             const location = Effect.uniforms
             this.set_uniform_float (location.bounds, 4, bounds)
@@ -129,14 +120,6 @@ export const RoundedCornersEffect = registerClass (
             this.set_uniform_float (location.inner_clip_radius, 1, [
                 inner_radius,
             ])
-            this.set_uniform_float (location.skip, 1, [_skip])
-            this.queue_repaint ()
-        }
-
-        set skip (skip: boolean) {
-            this._skip = skip
-            const location = Effect.uniforms.skip
-            this.set_uniform_float (location, 1, [this._skip ? 1.0 : 0.0])
             this.queue_repaint ()
         }
     }

--- a/src/effect/shader/rounded_corners.frag
+++ b/src/effect/shader/rounded_corners.frag
@@ -9,7 +9,6 @@ uniform float clip_radius;
 uniform vec4  inner_bounds;
 uniform float inner_clip_radius;
 uniform vec2  pixel_step;
-uniform float skip;
 uniform float border_width;
 uniform vec4  border_color;
 uniform float smoothing;
@@ -80,30 +79,27 @@ float rounded_rect_coverage(vec2 p, vec4 bounds, float clip_radius, float expone
 }
 
 void main() {
-  if(skip < 1.0) {
-    
-    float exponent = smoothing * 10.0 + 2.0;
+  float exponent = smoothing * 10.0 + 2.0;
 
-    float radius = clip_radius * 0.5 * exponent;
+  float radius = clip_radius * 0.5 * exponent;
 
-    float max_radius = min(bounds.z - bounds.x, bounds.w - bounds.y) * 0.5;
+  float max_radius = min(bounds.z - bounds.x, bounds.w - bounds.y) * 0.5;
 
-    if(radius > max_radius) {
-      exponent *= max_radius / radius;
-      radius = max_radius;
-    }
-
-    float inner_radius = inner_clip_radius * (radius / clip_radius);
-
-    vec2 texture_coord = cogl_tex_coord0_in.xy / pixel_step;
-
-    float outer_alpha = rounded_rect_coverage(texture_coord, bounds, radius, exponent);
-    if(border_width > 0.1) {
-      float inner_alpha = rounded_rect_coverage(texture_coord, inner_bounds, inner_radius, exponent);
-      float border_alpha = clamp(outer_alpha - inner_alpha, 0.0, 1.0) * cogl_color_out.a;
-
-      cogl_color_out = mix(cogl_color_out, vec4(border_color.rgb, 1.0), border_alpha * border_color.a);
-    }
-    cogl_color_out *=  outer_alpha;
+  if(radius > max_radius) {
+    exponent *= max_radius / radius;
+    radius = max_radius;
   }
+
+  float inner_radius = inner_clip_radius * (radius / clip_radius);
+
+  vec2 texture_coord = cogl_tex_coord0_in.xy / pixel_step;
+
+  float outer_alpha = rounded_rect_coverage(texture_coord, bounds, radius, exponent);
+  if(border_width > 0.1) {
+    float inner_alpha = rounded_rect_coverage(texture_coord, inner_bounds, inner_radius, exponent);
+    float border_alpha = clamp(outer_alpha - inner_alpha, 0.0, 1.0) * cogl_color_out.a;
+
+    cogl_color_out = mix(cogl_color_out, vec4(border_color.rgb, 1.0), border_alpha * border_color.a);
+  }
+  cogl_color_out *=  outer_alpha;
 }


### PR DESCRIPTION
Closes #44 

Remove RoundedCornersEffect when window is maximized, and add it back when window is un-maximized instead of setup 'skip' uniform variable in shader.

This change should reduce pressure of gpu.