### PR TITLE
Allocate shadow actor when position & size of window changed

### DIFF
--- a/@imports/ui/main.d.ts
+++ b/@imports/ui/main.d.ts
@@ -12,3 +12,13 @@ declare const layoutManager: {
     _startingUp: boolean,
     connect (_: 'startup-complete', cb: () => void)
 } & GObject.Object
+
+declare const overview: {
+    _overview: {
+        controls: {
+            _workspacesDisplay: {
+                _leavingOverview: boolean
+            }
+        }
+    }
+}

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -1,6 +1,5 @@
 // imports.gi
 import * as Meta           from '@gi/Meta'
-import * as Clutter        from '@gi/Clutter'
 import { Settings }        from '@gi/Gio'
 
 // gnome modules
@@ -15,7 +14,6 @@ import { constants }       from '@me/utils/constants'
 import { global }          from '@global'
 import * as types          from '@me/utils/types'
 import { Actor }           from '@gi/Clutter'
-import { WindowPreview }   from '@imports/ui/windowPreview'
 
 // --------------------------------------------------------------- [end imports]
 
@@ -178,33 +176,4 @@ export function ShouldHasRoundedCorners (
         (fullscreen && cfg.keep_rounded_corners.fullscreen)
 
     return should_has_rounded_corners
-}
-
-/** Compute size & position of shadow actor for window in overview */
-export function UpdateShadowOfWindowPreview (win_preview: WindowPreview) {
-    const win = win_preview._windowActor.meta_window
-    const shadow_clone = win_preview.get_child_at_index (0)
-
-    if (shadow_clone?.get_name () != constants.OVERVIEW_SHADOW_ACTOR) {
-        return
-    }
-
-    shadow_clone.get_constraints ().forEach ((c) => {
-        shadow_clone.remove_constraint (c)
-    })
-
-    const paddings =
-        constants.SHADOW_PADDING *
-        (win_preview.window_container.width / win.get_frame_rect ().width) *
-        WindowScaleFactor (win)
-
-    for (let i = 0; i < 4; i++) {
-        shadow_clone.add_constraint (
-            new Clutter.BindConstraint ({
-                coordinate: i,
-                source: win_preview.window_container,
-                offset: i < 2 ? -paddings : paddings * 2,
-            })
-        )
-    }
 }


### PR DESCRIPTION
Create a class named `OverviewShadowActor` to copy shadow of rounded corners window and insert it to behind of window preview in overview, also override `vfunc_allocate()` method so that when size of window changed in overview, size&position of shadow will be updated correctly.

This PR can clear the warning error when opening/closing overview (#50), and also fix glitch in overview (#39):

[录屏 2022年09月08日 14时22分54秒.webm](https://user-images.githubusercontent.com/32430186/189089588-6d64b183-2e55-447d-a7d7-6916ae8b9f0e.webm)
