### PR TITLE
Hide shadow for Compiz Window Effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@
 
 ## Compatibility
 
-- [_Compiz alike magic lamp effect_](https://extensions.gnome.org/extension/3740/compiz-alike-magic-lamp-effect/)
+- [_Compiz alike magic lamp effect_](https://extensions.gnome.org/extension/3740/compiz-alike-magic-lamp-effect/) / [_Compiz windows effect_](https://github.com/hermes83/compiz-windows-effect)
   
-  Hide shadow when magic lamp effect running.
-  Need to restart (disable then enable) this extension when _Compiz alike magic lamp effect_ enabled. 
+  Hide shadow when magic lamp effect / wobbly effect running.
 
 ## Notes
 
@@ -46,16 +45,7 @@ It will install extensions to `~/.local/share/gnome-shell/extensions`
 ```bash
 git clone https://github.com/yilozt/rounded-window-corners
 cd rounded-window-corners
-yarn install && yarn ext:install
-```
-
-In NixOS, you can use `nix-shell` to setup development shell then install
-extensions to `~/.local/share/gnome-shell/extensions`.
-
-```bash
-git clone https://github.com/yilozt/rounded-window-corners
-cd rounded-window-corners
-nix-shell
+# Run `nix-shell` to setup development shell in NixOS
 yarn install && yarn ext:install
 ```
 
@@ -80,9 +70,7 @@ yarn po            # auto fill po file
 vim po/zh_CN.po    # now let's start edit
 ```
 
-You can run `yarn ext:install` to compile `.po` files and install extensions. In XOrg sessions, just press `Alt + F2 -> r` to restart gnome-session then preview the result.
-
-You can run `yarn dev` in your terminal to watch changes of `.po` files, once you have update `.po` files, it will compile and install extensions automatically.
+You can run `yarn dev` in terminal to watch changes of `.po` files, it will compile and install extensions automatically. In XOrg sessions, press `Alt + F2 -> r` to reload gnome-shell to preview the result.
 
 ## Development
 

--- a/src/compatibility/compiz_alike_magic_lamp_effect.ts
+++ b/src/compatibility/compiz_alike_magic_lamp_effect.ts
@@ -1,0 +1,68 @@
+import * as Clutter                   from '@gi/Clutter'
+import { source_remove, timeout_add } from '@gi/GLib'
+import { WindowActor }                from '@gi/Meta'
+import { global }                     from '@global'
+import { RoundedCornersManager }      from '@me/manager/rounded_corners_manager'
+
+export class CompizeAlikeMagicLampEffect {
+    rounded_corners_manager: RoundedCornersManager | null = null
+    minimized_id = 0
+    unminimize_id = 0
+    timeout_id = 0
+
+    enable (rounded_corners_manager: RoundedCornersManager | null) {
+        this.rounded_corners_manager = rounded_corners_manager
+
+        const wm = global.window_manager
+
+        // Connect 'minimized' signal, hide shadow actor when window minimized
+        this.minimized_id = wm.connect_after ('minimize', (_, actor) => {
+            this.rounded_corners_manager?.hide_shadow (actor.meta_window)
+            return false
+        })
+
+        // Restore visible of shadow when un-minimized
+        this.unminimize_id = wm.connect_after ('unminimize', (_, actor) => {
+            this.timeout_id = timeout_add (0, 10, () => {
+                this._restore_shadow (actor)
+                return false
+            })
+        })
+    }
+
+    private _restore_shadow (actor: WindowActor) {
+        const manager = this.rounded_corners_manager
+        // Handle visible of shader with Compiz alike magic lamp effect
+        // After MagicLampUnminimizeEffect completed, then show shadow
+        //
+        // https://github.com/hermes83/compiz-alike-magic-lamp-effect
+        const effect = actor.get_effect ('unminimize-magic-lamp-effect')
+        if (!effect) {
+            manager?.restore_shadow (actor.meta_window)
+            return
+        }
+
+        type Effect = Clutter.Effect & { timerId: Clutter.Timeline }
+        const timer_id = (effect as Effect).timerId
+
+        const id = timer_id.connect ('new-frame', (source) => {
+            if (timer_id.get_progress () > 0.98) {
+                manager?.restore_shadow (actor.meta_window)
+                source.disconnect (id)
+            }
+        })
+    }
+
+    disable () {
+        this.rounded_corners_manager = null
+        if (this.minimized_id != 0) {
+            global.window_manager.disconnect (this.minimized_id)
+            this.minimized_id = 0
+        }
+        if (this.unminimize_id != 0) {
+            global.window_manager.disconnect (this.unminimize_id)
+            this.unminimize_id = 0
+        }
+        source_remove (this.timeout_id)
+    }
+}

--- a/src/compatibility/compiz_windows_effect.ts
+++ b/src/compatibility/compiz_windows_effect.ts
@@ -1,0 +1,110 @@
+// eslint max-len 256
+
+import * as Meta                      from '@gi/Meta'
+import * as Clutter                   from '@gi/Clutter'
+import { Bin }                        from '@gi/St'
+import { global }                     from '@global'
+import { RoundedCornersManager }      from '@me/manager/rounded_corners_manager'
+import { Connections }                from '@me/utils/connections'
+import { source_remove, timeout_add } from '@gi/GLib'
+
+export class CompizeWindowEffect {
+    manager: RoundedCornersManager | null = null
+    connections: Connections | null = null
+
+    EFFECT_NAME = 'wobbly-compiz-effect'
+    allowedResizeOp = [
+        Meta.GrabOp.RESIZING_W,
+        Meta.GrabOp.RESIZING_E,
+        Meta.GrabOp.RESIZING_S,
+        Meta.GrabOp.RESIZING_N,
+        Meta.GrabOp.RESIZING_NW,
+        Meta.GrabOp.RESIZING_NE,
+        Meta.GrabOp.RESIZING_SE,
+        Meta.GrabOp.RESIZING_SW,
+    ]
+    timeout_id = 0
+
+    enable (rounded_corners_manager: RoundedCornersManager) {
+        this.manager = rounded_corners_manager
+        this.connections = new Connections ()
+
+        const display = global.display
+        this.connections.connect (
+            display,
+            'grab-op-begin',
+            (_: Meta.Display, win: Meta.Window, op: Meta.GrabOp) =>
+                (this.timeout_id = timeout_add (0, 10, () => {
+                    this.grabStart (win, op)
+                    return false
+                }))
+        )
+        this.connections.connect (
+            display,
+            'grab-op-end',
+            (_: Meta.Display, win: Meta.Window, op: Meta.GrabOp) =>
+                (this.timeout_id = timeout_add (0, 10, () => {
+                    this.grabEnd (win, op)
+                    return false
+                }))
+        )
+    }
+
+    private grabStart (window: Meta.Window, op: Meta.GrabOp) {
+        if (!op) {
+            return
+        }
+
+        const actor: Meta.WindowActor | null = window.get_compositor_private ()
+        if (actor?.get_effect (this.EFFECT_NAME)) {
+            const shadow = this.manager?.query_shadow (window)
+            this.manager?.hide_shadow (window)
+            if (shadow) {
+                (shadow.first_child as Bin).style = 'opacity: 0;'
+            }
+        }
+    }
+
+    private grabEnd (window: Meta.Window, op: Meta.GrabOp) {
+        if (!op) {
+            return
+        }
+
+        const actor: Meta.WindowActor = window.get_compositor_private ()
+
+        const effect = actor?.get_effect (this.EFFECT_NAME)
+        if (!effect) {
+            this.manager?.restore_shadow (window)
+            this.manager?._on_focus_changed (window)
+            return
+        }
+        this.manager?.restore_shadow (window)
+
+        type Effect = Clutter.Effect & { timerId: Clutter.Timeline }
+        const timer_id = (effect as Effect).timerId
+
+        if (op == Meta.GrabOp.MOVING) {
+            const id = timer_id.connect ('stopped', (source) => {
+                this.manager?._on_focus_changed (window)
+                source.disconnect (id)
+            })
+        }
+        if (this.allowedResizeOp.includes (op)) {
+            const id = timer_id.connect ('new-frame', (source) => {
+                if (timer_id.get_progress () > 0.9) {
+                    this.manager?._on_focus_changed (window)
+                    source.disconnect (id)
+                }
+            })
+        }
+    }
+
+    disable () {
+        this.connections?.disconnect_all ()
+        this.connections = null
+
+        this.manager = null
+
+        source_remove (this.timeout_id)
+    }
+}

--- a/src/compatibility/index.ts
+++ b/src/compatibility/index.ts
@@ -1,0 +1,25 @@
+import { CompizeAlikeMagicLampEffect } from '@me/compatibility/compiz_alike_magic_lamp_effect'
+import { RoundedCornersManager }       from '@me/manager/rounded_corners_manager'
+
+type DetailCompatibility = {
+    enable(rounded_corners_manager: RoundedCornersManager | null): void
+    disable(): void
+}
+
+export class Compatibility {
+    private enable_list: null | DetailCompatibility[] = null
+    enable (rounded_corners_manager: RoundedCornersManager | null) {
+        this.enable_list = [new CompizeAlikeMagicLampEffect ()]
+
+        for (const e of this.enable_list) {
+            e.enable (rounded_corners_manager)
+        }
+    }
+
+    disable () {
+        for (const e of this.enable_list ?? []) {
+            e.disable ()
+        }
+        this.enable_list = null
+    }
+}

--- a/src/compatibility/index.ts
+++ b/src/compatibility/index.ts
@@ -1,4 +1,5 @@
 import { CompizeAlikeMagicLampEffect } from '@me/compatibility/compiz_alike_magic_lamp_effect'
+import { CompizeWindowEffect }         from '@me/compatibility/compiz_windows_effect'
 import { RoundedCornersManager }       from '@me/manager/rounded_corners_manager'
 
 type DetailCompatibility = {
@@ -9,7 +10,10 @@ type DetailCompatibility = {
 export class Compatibility {
     private enable_list: null | DetailCompatibility[] = null
     enable (rounded_corners_manager: RoundedCornersManager | null) {
-        this.enable_list = [new CompizeAlikeMagicLampEffect ()]
+        this.enable_list = [
+            new CompizeAlikeMagicLampEffect (),
+            new CompizeWindowEffect (),
+        ]
 
         for (const e of this.enable_list) {
             e.enable (rounded_corners_manager)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { settings }                   from '@me/utils/settings'
 import { Services }                   from '@me/dbus/services'
 import { LinearFilterEffect }         from '@me/effect/linear_filter_effect'
 import { init_translations }          from '@me/utils/i18n'
+import { Compatibility }              from '@me/compatibility/index'
 
 // types, which will be removed in output
 import { WM }                         from '@gi/Shell'
@@ -41,6 +42,7 @@ export class Extension {
 
     private _services: Services | null = null
     private _rounded_corners_manager: RoundedCornersManager | null = null
+    private _compatibility: Compatibility | null = null
 
     private _fs_timeout_id = 0
 
@@ -59,6 +61,7 @@ export class Extension {
 
         this._services = new Services ()
         this._rounded_corners_manager = new RoundedCornersManager ()
+        this._compatibility = new Compatibility ()
 
         this._services.export ()
 
@@ -239,7 +242,7 @@ export class Extension {
             })
         }
 
-        // Window Size Changed
+        // This method will be called when window maximized & tiled
         WindowManager.prototype._sizeChangeWindowDone = function (
             shell_wm,
             actor
@@ -297,6 +300,7 @@ export class Extension {
 
         // Set all props to null
         this._rounded_corners_manager = null
+        this._compatibility = null
         this._services = null
 
         _log ('Disabled')
@@ -304,10 +308,12 @@ export class Extension {
 
     private _enable_effect_managers () {
         this._rounded_corners_manager?.enable ()
+        this._compatibility?.enable (this._rounded_corners_manager)
     }
 
     private _disable_effect_managers () {
         this._rounded_corners_manager?.disable ()
+        this._compatibility?.disable ()
     }
 }
 

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -126,4 +126,4 @@ export const connections = {
 type _Map = Map<GObject.Object, { [signal_name: string]: number[] }>
 
 type Handler<T extends GObject.Object> = Parameters<T['connect']>
-type DefaultHandler = [string, (_: unknown[]) => unknown]
+type DefaultHandler = [string, (...params: never[]) => unknown]


### PR DESCRIPTION
When [Compiz windows effect](https://github.com/hermes83/compiz-windows-effect) running, the shadow of rounded corners will not be effect, because shadow of rounded corners window is not a part of window, it just a clutter.actor behind window.

This pr will hide shadow when effect of compiz window effect running, restore it when effect stopped.


https://user-images.githubusercontent.com/3246/189512740-5a0d893b-9ebf-45c6-baf5-96a3f03af9a5.mp4

Closes #37 
