### PR TITLE
Add GNOME 44 support

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "rounded-window-corners@yilozt",
   "version": "10",
   "url": "https://github.com/yilozt/rounded-window-corners",
-  "shell-version": ["40", "41", "42", "43"]
+  "shell-version": ["40", "41", "42", "43", "44"]
 }


### PR DESCRIPTION
This PR adds support for GNOME 44.

Only the `metadata.json` file is changed, since I didn't find any bug in a 30-minute use. I tested with both GTK3 and Electron apps.