### PR TITLE
Fix blurry text when un-minimized window

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -69,6 +69,7 @@ export type ExtensionsWindowActor = WindowActor & {
   __rwc_rounded_window_info?: {
     shadow: Bin
     visible_binding: Binding
+    unminimized_timeout_id: number
   }
   __rwc_blurred_window_info?: {
     blur_actor: Actor


### PR DESCRIPTION
Reproduce this issues in Gnome 43.3 (Wayland)

When minimized Matlab then un-minimized it in Wayland, application will be blurry until you have move mouse over it to update elements.

Now, extensions will try to call queue_relayout() after 300ms timeout to active window then remove blurry glitch.

Fixes #104, Fixes #111
