### PR TITLE
Added unfocused window border colour changing

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -4,8 +4,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-12-10 10:05+0000\n"
 "Last-Translator: Nadjib Chergui <chergui.cnadjib@outlook.com>\n"
-"Language-Team: Arabic <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/ar/>\n"
+"Language-Team: Arabic <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/ar/>\n"
 "Language: ar\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,12 +13,11 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.3-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "أضف بند الإعدادات في قائمة النقرة اليمنى للخلفية"
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr "إضافة نافذة"
 
@@ -66,8 +65,7 @@ msgstr "عرض الحدود"
 msgid "Bottom"
 msgstr "أسفل"
 
-#: src/preferences/pages/blacklist.ts:64
-#: src/preferences/pages/custom.ts:174
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "لا يمك‏ن إضافته للقائمة، لأنه موجودة فيها"
 
@@ -93,7 +91,7 @@ msgstr "خاص"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "تخصيص نمط ظل النافذة ذات الزوايا المدورة"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "تصحيح الأخطاء"
 
@@ -109,7 +107,7 @@ msgstr "تفعيل"
 msgid "Enable custom settings for this window"
 msgstr "تفعيل الإعدادات الخاصة بهذه النافذة"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "تفعيل التسجيلات التقنية"
@@ -156,9 +154,11 @@ msgstr "يسار"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "ليست كل التطبيقات تعمل مع تأثير الزوايا المدورة، أضفهم لإيقاف التأثيرات لهم."
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Opacity"
 msgstr ""
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "فتح نافذة إعادة الضبط"
 
@@ -186,7 +186,7 @@ msgstr "اختر نافذةً لإضافتها إلى القائمة"
 msgid "Remove Window from this List"
 msgstr "إزالة النافذة من القائمة"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "إعادة ضبط الإعدادات"
 
@@ -194,13 +194,14 @@ msgstr "إعادة ضبط الإعدادات"
 msgid "Right"
 msgstr "يمين"
 
-#: src/utils/ui.ts:103
-#: src/utils/ui.ts:132
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "إعدادات الزوايا المدورة..."
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 "شغل <i>journalctl -o cat -f /usr/bin/gnome-shell</i> في الطرفية لتظهر "
 "التسجيلات"
@@ -217,7 +218,8 @@ msgstr "اختر الأشياء لإعادة ضبطها"
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 
 #: src/preferences/pages/general.ui:47
@@ -231,7 +233,9 @@ msgid "Skip LibHandy Applications"
 msgstr "تجنب تطبيقات (LibHandy)"
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 "بعض التطبيقات التي تستخدم (LibAdwaita) أو (LibHandy) لديها زوايا دائرية "
 "فعلًا، إذن يمكن تجنبها بواسطة هذه الإعدادات"
@@ -248,16 +252,16 @@ msgstr "هذه الإعدادات ستحاول في التأثير على كل �
 msgid "Top"
 msgstr "أعلى"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 #, fuzzy
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "حاول إضافة الزوايا المدورة لطرفية كيتي (Kitty) في وايلاند (Wayland)"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "تعديلات"
 
@@ -268,6 +272,11 @@ msgstr "النافذة الغير المختارة"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "نمط ظل النافذة الغير المختارة"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "لون الحدود"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -4,20 +4,19 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-04-25 17:52+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
-"Language-Team: Czech <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/cs/>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/cs/>\n"
 "Language: cs\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Přidat položku Nastavení do nabídky pravého tlačítka myši na pozadí"
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr "Přidat okno"
 
@@ -64,12 +63,11 @@ msgstr "Šířka okraje"
 msgid "Bottom"
 msgstr "Spodní"
 
-#: src/preferences/pages/blacklist.ts:65
-#: src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Nelze přidat do seznamu, protože existuje"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Nelze vybrat okno z této pozice"
 
@@ -90,28 +88,28 @@ msgstr "Vlastní"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Přizpůsobení stínu zaobleného rohu okna"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Ladění"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Úprava stínu pro okna se zaoblenými rohy"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Povolit"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Povolit vlastní nastavení tohoto okna"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Povolit protokol"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Rozbalte tento řádek a vyberte okno."
 
@@ -153,9 +151,11 @@ msgstr "Vlevo"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Ne všechny aplikace umí dobře pracovat s efekty zaoblených rohů, přidejte je "
 "do tohoto seznamu a zakažte efekty.\n"
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Neprůhlednost"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Otevřít dialogové okno Obnovit předvolby"
 
@@ -187,7 +187,7 @@ msgstr "Vyberte okno, které chcete přidat do seznamu"
 msgid "Remove Window from this List"
 msgstr "Odebrat okno z tohoto seznamu"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Obnovit předvolby"
 
@@ -195,12 +195,14 @@ msgstr "Obnovit předvolby"
 msgid "Right"
 msgstr "Vpravo"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Nastavení zaoblených rohů..."
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 "Pro zobrazení protokolu spusťte v terminálu příkaz <i>journalctl -o cat -f /"
 "usr/bin/gnome-shell</i>"
@@ -217,7 +219,8 @@ msgstr "Vyberte položky, které chcete resetovat"
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Nastavte různé výplně klipů přidáním okna do tohoto seznamu.\n"
 "\n"
@@ -235,7 +238,9 @@ msgid "Skip LibHandy Applications"
 msgstr "Přeskočit aplikace LibHandy"
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 "Některé aplikace napsané pomocí LibAdwaita nebo LibHandy již mají nativní "
 "zaoblené rohy, takže je můžeme přeskočit pomocí těchto nastavení"
@@ -252,15 +257,15 @@ msgstr "Toto nastavení se pokusí ovlivnit všechna okna"
 msgid "Top"
 msgstr "Nahoře"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Pokusit se přidat zaoblené rohy do aplikace Kitty Terminal ve Waylandu"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Upravit výplně klipů pro Kitty Terminal"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Vylepšení"
 
@@ -271,6 +276,11 @@ msgstr "Okno bez zaměření"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Styl stínu nezaměřeného okna"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Barva okraje"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/de.po
+++ b/po/de.po
@@ -3,15 +3,15 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-04-18 06:49+0000\n"
 "Last-Translator: Jörn Weigend <das.jott@gmail.com>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/de/>\n"
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.17\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Füge Einstellungseintrag zum Rechtsklickmenü des Hintergrunds hinzu"
 
@@ -62,11 +62,11 @@ msgstr "Rahmenbreite"
 msgid "Bottom"
 msgstr "Unten"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Zufügen nicht möglich, da bereits in Liste"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Kann kein Fenster von dieser Position auswählen"
 
@@ -87,28 +87,28 @@ msgstr "Benutzerdefiniert"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Passe den Schatten von Fenstern mit abgerundeten Ecken an"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Schatteneinstellungen"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Aktiviere benutzerdefinierte Einstellungen für dieses Fenster"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Logging aktivieren"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Eintrag aufklappen, um ein Fenster auszuwählen."
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Deckkraft"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Zurücksetzungsoptionen anzeigen"
 
@@ -187,7 +187,7 @@ msgstr "Fenster auswählen, um es der Liste hinzuzufügen"
 msgid "Remove Window from this List"
 msgstr "Entferne Fenster aus der Liste"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Einstellungen zurücksetzen"
 
@@ -195,11 +195,11 @@ msgstr "Einstellungen zurücksetzen"
 msgid "Right"
 msgstr "Rechts"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Einstellungen für abgerundete Ecken..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -259,16 +259,16 @@ msgstr "Diese Einstellungen versuchen auf alle Fenster angewendet zu werden"
 msgid "Top"
 msgstr "Oben"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 "Versuche abgerundete Ecken dem Kitty Terminal unter Wayland hinzuzufügen"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Optimiere die Innenabstände für Kitty Terminal"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Optimierungen"
 
@@ -279,6 +279,11 @@ msgstr "Unfokussiertes Fenster"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Schattenstil für unfokussierte Fenster"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Rahmenfarbe"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/eo.po
+++ b/po/eo.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.15.1-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
@@ -62,11 +62,11 @@ msgstr "Randa larĝo"
 msgid "Bottom"
 msgstr "Malsupro"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr ""
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr ""
 
@@ -87,28 +87,28 @@ msgstr "Propra"
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr ""
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr ""
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Ŝalti"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr ""
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr ""
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Opako"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr ""
 
@@ -181,7 +181,7 @@ msgstr ""
 msgid "Remove Window from this List"
 msgstr ""
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr ""
 
@@ -189,11 +189,11 @@ msgstr ""
 msgid "Right"
 msgstr "Dekstro"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr ""
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -243,15 +243,15 @@ msgstr ""
 msgid "Top"
 msgstr "Supro"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr ""
 
@@ -262,6 +262,11 @@ msgstr "Eksterfokusa fenestro"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr ""
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Randa koloro"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/es.po
+++ b/po/es.po
@@ -3,15 +3,15 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-03-02 12:35+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/es/>\n"
 "Language: es\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Añadir entrada de configuración en el menú de click derecho del fondo de "
@@ -67,11 +67,11 @@ msgstr "Ancho de los bordes"
 msgid "Bottom"
 msgstr "Abajo"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "No se puede añadir a la lista, porque ya existe"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "No se puede elegir una ventana desde esta posición"
 
@@ -92,28 +92,28 @@ msgstr "Personalizado"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalizar la sombra de la ventana redondeada"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Depurar"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Editar sombras de las ventanas con bordes redondeados"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Habilitar opciones personalizadas para esta ventana"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Habilitar registro"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Amplíe esta fila para elegir una ventana."
 
@@ -172,7 +172,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Opacidad"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Abrir el diálogo de Restaurar preferencias"
 
@@ -192,7 +192,7 @@ msgstr "Selecciona una ventana para añadirla a la lista"
 msgid "Remove Window from this List"
 msgstr "Quitar una ventana de esta lista"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Restaurar preferencias"
 
@@ -200,11 +200,11 @@ msgstr "Restaurar preferencias"
 msgid "Right"
 msgstr "Derecha"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Configuración de Rounded Corners..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -262,15 +262,15 @@ msgstr "Estas configuraciones intentan aplicarse a todas las ventanas"
 msgid "Top"
 msgstr "Arriba"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Intentar añadir bordes redondeados a la terminal Kitty en Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Optimizar el relleno para Kitty Terminal"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Retoques"
 
@@ -281,6 +281,11 @@ msgstr "Ventana desenfocada"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Estilo de sombra de ventana no enfocada"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Color de los bordes"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/et.po
+++ b/po/et.po
@@ -5,7 +5,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
@@ -56,11 +56,11 @@ msgstr ""
 msgid "Bottom"
 msgstr ""
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr ""
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr ""
 
@@ -81,28 +81,28 @@ msgstr ""
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr ""
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr ""
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr ""
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr ""
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Opacity"
 msgstr ""
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgstr ""
 msgid "Remove Window from this List"
 msgstr ""
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr ""
 
@@ -183,11 +183,11 @@ msgstr ""
 msgid "Right"
 msgstr ""
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr ""
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -237,15 +237,15 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr ""
 
@@ -255,6 +255,10 @@ msgstr ""
 
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
+msgstr ""
+
+#: src/preferences/pages/general.ui:229
+msgid "Unfocused Border Color"
 msgstr ""
 
 #: src/preferences/widgets/edit-shadow-window.ui:66

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.15-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Lisää asetukset-rivi taustan kontekstivalikkoon"
 
@@ -62,11 +62,11 @@ msgstr "Reunan leveys"
 msgid "Bottom"
 msgstr "Alaosa"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr ""
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Ikkunaa ei voi valita tästä sijainnista"
 
@@ -87,28 +87,28 @@ msgstr "Mukautettu"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Mukauta pyöristetyn kulman varjoa"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Vianetsintä"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Muokkaa pyöristettyjen ikkunoiden varjoa"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Päälle"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Käytä kustomoituja asetuksia tälle ikkunalle"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Kirjoita lokiin"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Laajenna rivi valitaksesi ikkunan."
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Peittävyys"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Avaa asetusten nollausvalikko"
 
@@ -186,7 +186,7 @@ msgstr "Valitse ikkuna lisätäksesi sen listaan"
 msgid "Remove Window from this List"
 msgstr "Poista ikkuna listasta"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Nollaa asetukset"
 
@@ -194,11 +194,11 @@ msgstr "Nollaa asetukset"
 msgid "Right"
 msgstr "Oikea"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Kulmienpyöristyksen asetukset..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -256,15 +256,15 @@ msgstr "Tämä asetus pyrkii vaikuttamaan kaikkiin ikkunoihin"
 msgid "Top"
 msgstr "Yläosa"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Koita pyöristää Kitty-pääteohjelman kulmat Waylandissa"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Muokkaa Kitty-pääteohjelman ylijäämäleikkausta"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Hienosäädöt"
 
@@ -275,6 +275,11 @@ msgstr "Keskittämätön ikkuna"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Keskittämättömän ikkunan varjo"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Reunan väri"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,15 +3,15 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-10-11 16:02+0000\n"
 "Last-Translator: luxluth <delphin.blehoussi93@gmail.com>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/fr/>\n"
+"Language-Team: French <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/fr/>\n"
 "Language: fr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Ajoute un accès aux paramètres dans le menu clique-droit de l'arrière plan"
@@ -66,11 +66,11 @@ msgstr "Largeur de la bordure"
 msgid "Bottom"
 msgstr "Bas"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Impossible d'ajouter à la liste, car l'élément existe déjà"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Impossible de sélectionner une fenêtre depuis cette position"
 
@@ -91,28 +91,28 @@ msgstr "Customiser"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Customiser l'ombre de la bordure de la fenêtre"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Débogage"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Éditer l'ombre de la bordure de la fenêtre"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Activer"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Active les préférences customisées pour cette fenêtre"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Activer les journaux"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Développer la ligne pour choisir une fenêtre."
 
@@ -170,7 +170,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Opacité"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Ouvrir le dialogue de réinitialisation des paramètres"
 
@@ -190,7 +190,7 @@ msgstr "Sélectionner une fenêtre pour l'ajouter à la liste"
 msgid "Remove Window from this List"
 msgstr "Enlever la fenêtre de la liste"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Réinitialiser les préférences"
 
@@ -198,11 +198,11 @@ msgstr "Réinitialiser les préférences"
 msgid "Right"
 msgstr "Droite"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Paramètres de coins arrondis..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -261,15 +261,15 @@ msgstr "Ces paramètres vont tenter d'affecter toutes les fenêtres"
 msgid "Top"
 msgstr "Haut"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Essayer d'ajouter des coins arrondis à la console Kitty sous Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Customiser les marges de la console Kitty"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Customisations"
 
@@ -280,6 +280,11 @@ msgstr "Fenêtre non activ"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Style de l'ombre de la fenêtre non active"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Couleur de la bordure"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,20 +4,19 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-10-01 14:00+0000\n"
 "Last-Translator: olevo <imagyarcsik@gmail.com>\n"
-"Language-Team: Hungarian <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/hu/>\n"
+"Language-Team: Hungarian <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/hu/>\n"
 "Language: hu\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr ""
 
@@ -65,12 +64,11 @@ msgstr "A border szélessége"
 msgid "Bottom"
 msgstr "Alja"
 
-#: src/preferences/pages/blacklist.ts:65
-#: src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Sikertelen hozzáadás, ez már létezik"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr ""
 
@@ -91,28 +89,28 @@ msgstr "Egyéni"
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr ""
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Bekapcsolás"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Napló bekapcsolása"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr ""
 
@@ -154,16 +152,18 @@ msgstr "Bal"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 
 #: src/preferences/widgets/edit-shadow-window.ui:126
 msgid "Opacity"
 msgstr "Áttettszőség"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr ""
 
@@ -183,7 +183,7 @@ msgstr ""
 msgid "Remove Window from this List"
 msgstr ""
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr ""
 
@@ -191,12 +191,14 @@ msgstr ""
 msgid "Right"
 msgstr "Jobb"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr ""
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 
 #: src/preferences/widgets/reset_dialog.ts:96
@@ -211,7 +213,8 @@ msgstr ""
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 
 #: src/preferences/pages/general.ui:47
@@ -225,7 +228,9 @@ msgid "Skip LibHandy Applications"
 msgstr ""
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 
 #: src/preferences/widgets/edit-shadow-window.ui:107
@@ -240,15 +245,15 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr ""
 
@@ -259,6 +264,11 @@ msgstr ""
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr ""
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "A border széle"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/id.po
+++ b/po/id.po
@@ -3,15 +3,15 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-05-24 00:51+0000\n"
 "Last-Translator: Reza Almanda <rezaalmanda27@gmail.com>\n"
-"Language-Team: Indonesian <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/id/>\n"
+"Language-Team: Indonesian <https://hosted.weblate.org/projects/rounded-"
+"window-corners/rounded-window-corners/id/>\n"
 "Language: id\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Tambahkan Entri Pengaturan di menu klik kanan Latar Belakang"
 
@@ -64,11 +64,11 @@ msgstr "Lebar Border"
 msgid "Bottom"
 msgstr "Bawah"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Tidak dapat menambahkan ke daftar, karena sudah ada"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Tidak dapat memilih jendela dari posisi ini"
 
@@ -89,28 +89,28 @@ msgstr "Kustom"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Sesuaikan bayangan jendela sudut membulat"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Edit Bayangan untuk Jendela Sudut Bulat"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Aktifkan"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Aktifkan pengaturan khusus untuk jendela ini"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Aktifkan Log"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Luaskan baris ini untuk memilih jendela."
 
@@ -168,7 +168,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Kegelapan"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Buka Dialog Atur Ulang Preferensi"
 
@@ -188,7 +188,7 @@ msgstr "Pilih Jendela untuk ditambahkan ke daftar"
 msgid "Remove Window from this List"
 msgstr "Hapus Jendela dari Daftar ini"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Atur Ulang Preferensi"
 
@@ -196,11 +196,11 @@ msgstr "Atur Ulang Preferensi"
 msgid "Right"
 msgstr "Kanan"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Pengaturan Sudut Bulat..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -259,15 +259,15 @@ msgstr "Pengaturan ini akan mencoba mempengaruhi semua jendela"
 msgid "Top"
 msgstr "Atas"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Coba tambahkan sudut membulat ke Terminal Kitty di Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Tweak lapisan klip untuk Terminal Kitty"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Oprekan"
 
@@ -278,6 +278,11 @@ msgstr "Jendela Tidak Fokus"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Gaya Bayangan Jendela Tidak Fokus"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Warna Border"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/it.po
+++ b/po/it.po
@@ -4,22 +4,21 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-11-11 20:32+0000\n"
 "Last-Translator: CraftWorks <thelonegamer87@gmail.com>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/it/>\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/it/>\n"
 "Language: it\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Aggiungi tra le impostazioni del menu del tasto destro del mouse sul "
 "Background"
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr "Aggiungi Finestra"
 
@@ -66,12 +65,11 @@ msgstr "Larghezza del bordo"
 msgid "Bottom"
 msgstr "Sotto"
 
-#: src/preferences/pages/blacklist.ts:65
-#: src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Impossibile aggiungerlo alla lista, perchè esiste già"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Impossibile selezionare la finestra da questa posizione"
 
@@ -92,28 +90,28 @@ msgstr "Personalizza"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalizza l'ombra del bordo arrotondato"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Modifica l'ombra per le finestre arrotondate"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Abilita"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Abilita le impostazioni personalizzate per questa finestra"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Abilita i Log"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Espandi questa riga per selezionare una finestra."
 
@@ -155,9 +153,11 @@ msgstr "Sinistra"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Non tutte le applizazioni funzionano bene con l'effetto dei bordo "
 "arrotondati, aggiungili a questa lista per disabilitarlo.\n"
@@ -169,7 +169,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Opacità"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Apri il Dialogo Per Resettare le Preferenze"
 
@@ -189,7 +189,7 @@ msgstr "Seleziona una finestra da aggiungere alla lista"
 msgid "Remove Window from this List"
 msgstr "Rimuovi Finestra dalla lista"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Reimposta Preferenze"
 
@@ -197,12 +197,14 @@ msgstr "Reimposta Preferenze"
 msgid "Right"
 msgstr "Destra"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Impostazioni per i Bordi Arrotondati..."
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 "Esegui <i>journalctl -o cat -f /usr/bin/gnome-shell</i> nel terminale per "
 "vedere i log"
@@ -219,7 +221,8 @@ msgstr "Seleziona Item da reimpostare"
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Imposta un clip padding diverso aggiungendo una finestra in questa lista.\n"
 "\n"
@@ -237,7 +240,9 @@ msgid "Skip LibHandy Applications"
 msgstr "Ignora Applicazioni LibHandy"
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 "Alcune applicazioni scritte con LibAdwaita o LibHandy hanno già i bordi "
 "arrotondati, quindi possiamo ignorarli con queste impostazioni"
@@ -254,15 +259,15 @@ msgstr ""
 msgid "Top"
 msgstr "Sopra"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Prova ad arrotondare i bordi al terminale Kitty su Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Modifiche"
 
@@ -273,6 +278,11 @@ msgstr ""
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr ""
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Colore del bordo"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/ja.po
+++ b/po/ja.po
@@ -3,15 +3,15 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-03-21 15:37+0000\n"
 "Last-Translator: maboroshin <maboroshin@users.noreply.hosted.weblate.org>\n"
-"Language-Team: Japanese <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/ja/>\n"
+"Language-Team: Japanese <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/ja/>\n"
 "Language: ja\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "背景の右クリックメニューに設定項目を追加"
 
@@ -62,11 +62,11 @@ msgstr "境界線の幅"
 msgid "Bottom"
 msgstr "下"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "既に存在するため、一覧に追加できません"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "この位置からウィンドウを選択できません"
 
@@ -87,28 +87,28 @@ msgstr "カスタマイズ"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "角丸ウィンドウの影を指定"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "デバッグ"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "角丸ウィンドウの影を編集"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "有効化"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "このウィンドウの独自設定を有効化"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "ログを有効化"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "この行を展開しウィンドウを選択。"
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "不透明度"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "設定初期化のダイアログを開く"
 
@@ -186,7 +186,7 @@ msgstr "一覧に追加するウィンドウを選択"
 msgid "Remove Window from this List"
 msgstr "この一覧からウィドウを除去"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "設定を初期化"
 
@@ -194,11 +194,11 @@ msgstr "設定を初期化"
 msgid "Right"
 msgstr "右"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "角丸の設定..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -256,15 +256,15 @@ msgstr "この設定はすべてのウィンドウへの効果を試みます"
 msgid "Top"
 msgstr "上"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr ""
 
@@ -275,6 +275,11 @@ msgstr ""
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr ""
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "境界線の色"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.14.1-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Legg til innstillingsoppføring i høyreklikksmenyen for bakgrunn"
 
@@ -64,11 +64,11 @@ msgstr ""
 msgid "Bottom"
 msgstr ""
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr ""
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr ""
 
@@ -89,28 +89,28 @@ msgstr ""
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr ""
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr ""
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr ""
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr ""
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr ""
 
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Opacity"
 msgstr ""
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr ""
 
@@ -183,7 +183,7 @@ msgstr ""
 msgid "Remove Window from this List"
 msgstr ""
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr ""
 
@@ -191,11 +191,11 @@ msgstr ""
 msgid "Right"
 msgstr ""
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr ""
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -245,15 +245,15 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr ""
 
@@ -263,6 +263,10 @@ msgstr ""
 
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
+msgstr ""
+
+#: src/preferences/pages/general.ui:229
+msgid "Unfocused Border Color"
 msgstr ""
 
 #: src/preferences/widgets/edit-shadow-window.ui:66

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,15 +3,15 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-03-02 12:35+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
-"Language-Team: Dutch <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/nl/>\n"
+"Language-Team: Dutch <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/nl/>\n"
 "Language: nl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Voorkeurenitem tonen in rechtermuisknopmenu van achtergrond"
 
@@ -64,11 +64,11 @@ msgstr "Randbreedte"
 msgid "Bottom"
 msgstr "Onderaan"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Het toevoegen is mislukt omdat het item er al op staat"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Er kan vanaf deze positie geen venster worden gekozen"
 
@@ -89,28 +89,28 @@ msgstr "Aangepast"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Pas de schaduw van afgeronde vensters aan"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Foutopsporing"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Pas de schaduw van afgeronde vensters aan"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Gebruik aangepaste voorkeuren in dit venster"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Logboek bijhouden"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Klap deze rij uit om een venster te kiezen."
 
@@ -169,7 +169,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Doorzichtigheid"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Open het voorkeurenherstelvenster"
 
@@ -189,7 +189,7 @@ msgstr "Kies een toe te voegen venster"
 msgid "Remove Window from this List"
 msgstr "Venster verwijderen van lijst"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Voorkeuren herstellen"
 
@@ -197,11 +197,11 @@ msgstr "Voorkeuren herstellen"
 msgid "Right"
 msgstr "Rechts"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Afgeronde hoeken-voorkeuren…"
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -260,15 +260,15 @@ msgstr "Deze voorkeuren zijn van toepassing op alle vensters"
 msgid "Top"
 msgstr "Bovenaan"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Kitty Terminal voorzien van afgeronde hoeken op Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Opvullingen van Kitty Terminal verbeteren"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Trucs"
 
@@ -279,6 +279,11 @@ msgstr "Ongefocust venster"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Schaduw stijl van ongefocust venster"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Randkleur"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/pl.po
+++ b/po/pl.po
@@ -4,8 +4,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-10-29 05:13+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
-"Language-Team: Polish <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/pl/>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/pl/>\n"
 "Language: pl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,14 +13,13 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Dodaj opcję do menu pojawiającego się po kliknięciu prawym przyciskiem myszy "
 "na pulpicie"
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr "Dodaj okno"
 
@@ -67,12 +66,11 @@ msgstr "Grubość obramowania"
 msgid "Bottom"
 msgstr "Dół"
 
-#: src/preferences/pages/blacklist.ts:65
-#: src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Nie można dodać do listy, ponieważ to już istnieje"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Nie można wybrać okna z tej pozycji"
 
@@ -93,28 +91,28 @@ msgstr "Własne"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Dostosuj cień okien z zaokrąglonymi krawędziami"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Debuguj"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Edytuj cienie okien z zaokrąglonymi krawędziami"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Włącz"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Włącz własne ustawienia dla tego okna"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Włącz logi"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Zwiększ ten rząd aby wybrać okno"
 
@@ -156,9 +154,11 @@ msgstr "Lewo"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Nie wszystkie aplikacje mogą działać dobrze z efektami zaokrąglonych "
 "krawędzi, dodaj je do tej listy by wyłączyć efekty.\n"
@@ -169,7 +169,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Nieprzezroczystość"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Otwórz okno resetowania ustawień"
 
@@ -189,7 +189,7 @@ msgstr "Wybierz okno do dodania na listę"
 msgid "Remove Window from this List"
 msgstr "Usuń okno z tej listy"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Przywróć preferencje do domyślnych"
 
@@ -197,12 +197,14 @@ msgstr "Przywróć preferencje do domyślnych"
 msgid "Right"
 msgstr "Prawo"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Ustawienia zaokrąglonych narożników..."
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 "Aby zobaczyć log, uruchom w terminalu polecenie <i>journalctl -o cat -f /usr/"
 "bin/gnome-shell</i>"
@@ -219,7 +221,8 @@ msgstr "Wybierz elementy do zresetowania"
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 
 #: src/preferences/pages/general.ui:47
@@ -233,7 +236,9 @@ msgid "Skip LibHandy Applications"
 msgstr "Pomiń aplikacje wykorzytujące LibHandy"
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 "Aplikacje wykorzystujące LibAdwaita i LibHandy natywnie wspierają "
 "zaokrąglone narożniki, więc możemy je pominąć wykorzystując te ustawienia"
@@ -250,15 +255,15 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Ulepszenia"
 
@@ -269,6 +274,11 @@ msgstr "Nieaktywne okno"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Styl cienia nieaktywnego okna"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Kolor obramowania"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/pt.po
+++ b/po/pt.po
@@ -4,21 +4,20 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-12-21 14:06+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
-"Language-Team: Portuguese <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/pt/>\n"
+"Language-Team: Portuguese <https://hosted.weblate.org/projects/rounded-"
+"window-corners/rounded-window-corners/pt/>\n"
 "Language: pt\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Adicionar entrada de configurações no menu de fundo do botão direito do rato"
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr "Adicionar janela"
 
@@ -69,8 +68,7 @@ msgstr "Largura da Borda"
 msgid "Bottom"
 msgstr "Parte Inferior"
 
-#: src/preferences/pages/blacklist.ts:64
-#: src/preferences/pages/custom.ts:174
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Não é possível adicionar à lista porque já existe"
 
@@ -95,7 +93,7 @@ msgstr "Personalizado"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalize a sombra dos cantos da janela"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Debug"
 
@@ -111,7 +109,7 @@ msgstr "Ativar"
 msgid "Enable custom settings for this window"
 msgstr "Ativar customizações nesta janela"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Ativar Log"
@@ -158,9 +156,11 @@ msgstr "Esquerda"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Nem todas as aplicações conseguem funcionar bem com efeitos de cantos "
 "arredondados, adicione-os a esta lista para desativar os efeitos.\n"
@@ -172,7 +172,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Abrir caixa de diálogo de Redefinição de Configurações"
 
@@ -192,7 +192,7 @@ msgstr "Escolher Janela para adicionar à lista"
 msgid "Remove Window from this List"
 msgstr "Remover Janela desta Lista"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Redefinir Preferências"
 
@@ -200,13 +200,14 @@ msgstr "Redefinir Preferências"
 msgid "Right"
 msgstr "Direita"
 
-#: src/utils/ui.ts:103
-#: src/utils/ui.ts:132
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Configurações de Cantos Arredondados..."
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 "Execute <i>journalctl -o cat -f /usr/bin/gnome-shell</i> no terminal para "
 "ver o log"
@@ -223,10 +224,11 @@ msgstr "Selecionar Itens para Redefinir"
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
-"Configure diferentes recortes de margem adicionando uma janela a esta lista."
-"\n"
+"Configure diferentes recortes de margem adicionando uma janela a esta "
+"lista.\n"
 "\n"
 "O item da lista é uma parte da propriedade WM_CLASS da janela. Pode "
 "selecionar uma janela para adicioná-la a esta lista."
@@ -242,7 +244,9 @@ msgid "Skip LibHandy Applications"
 msgstr "Ignorar Aplicações Usando LibHandy"
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 "Algumas aplicações escritas usando LibAdwaita ou LibHandy já possuem cantos "
 "arredondados nativos, então podemos ignorá-los através dessas configurações"
@@ -259,15 +263,15 @@ msgstr "Estas configurações tentarão afetar todas as janelas"
 msgid "Top"
 msgstr "Parte Superior"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Tente adicionar cantos arredondados ao Terminal Kitty em Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Ajustar preenchimento de clipe para o Kitty Terminal"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Ajustes"
 
@@ -278,6 +282,11 @@ msgstr "Janela Desfocada"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Estilo de Sombra da Janela Desfocada"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Cor da Borda"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -12,12 +12,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr "Adicionar janela"
 
@@ -67,12 +66,11 @@ msgstr "Largura da Borda"
 msgid "Bottom"
 msgstr "Parte Inferior"
 
-#: src/preferences/pages/blacklist.ts:65
-#: src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Não é possível adicionar à lista porque já existe"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Não é possível selecionar uma janela a partir desta posição"
 
@@ -93,28 +91,28 @@ msgstr "Personalizado"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalize a sombra dos cantos da janela"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Editar a sombra dos cantos da janela"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Habilitar customizações nesta janela"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Habilitar Log"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Expanda esta linha para escolher uma janela."
 
@@ -156,9 +154,11 @@ msgstr "Esquerda"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Nem todos os aplicativos conseguem funcionar bem com efeitos de cantos "
 "arredondados, adicione-os a esta lista para desativar os efeitos.\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Abrir caixa de diálogo de Redefinição de Configurações"
 
@@ -190,7 +190,7 @@ msgstr "Escolher Janela para adicionar à lista"
 msgid "Remove Window from this List"
 msgstr "Remover Janela desta Lista"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Redefinir Preferências"
 
@@ -198,12 +198,14 @@ msgstr "Redefinir Preferências"
 msgid "Right"
 msgstr "Direita"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Configurações de Cantos Arredondados..."
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 "Execute <i>journalctl -o cat -f /usr/bin/gnome-shell</i> no terminal para "
 "ver o log"
@@ -220,10 +222,11 @@ msgstr "Selecionar Itens para Redefinir"
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
-"Configure diferentes recortes de margem adicionando uma janela a esta lista."
-"\n"
+"Configure diferentes recortes de margem adicionando uma janela a esta "
+"lista.\n"
 "\n"
 "O item da lista é uma parte da propriedade WM_CLASS da janela. Você pode "
 "selecionar uma janela para adicioná-la a esta lista."
@@ -239,7 +242,9 @@ msgid "Skip LibHandy Applications"
 msgstr "Ignorar Aplicativos Usando LibHandy"
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 "Alguns aplicativos escritos usando LibAdwaita ou LibHandy já possuem cantos "
 "arredondados nativos, então podemos ignorá-los através dessas configurações"
@@ -256,15 +261,15 @@ msgstr "Estas configurações tentarão afetar todas as janelas"
 msgid "Top"
 msgstr "Parte Superior"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Ajustes"
 
@@ -275,6 +280,11 @@ msgstr "Janela Desfocada"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Estilo de Sombra da Janela Desfocada"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Cor da Borda"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/rounded-window-corners@yilozt.pot
+++ b/po/rounded-window-corners@yilozt.pot
@@ -4,7 +4,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "Project-Id-Version: 12\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Enable custom settings for this window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr ""
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Opacity"
 msgstr ""
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr ""
 
@@ -174,7 +174,7 @@ msgstr ""
 msgid "Remove Window from this List"
 msgstr ""
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr ""
 
@@ -187,7 +187,7 @@ msgstr ""
 msgid "Rounded Corners Settings..."
 msgstr ""
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
 msgstr ""
 
@@ -232,15 +232,15 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr ""
 
@@ -250,6 +250,10 @@ msgstr ""
 
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
+msgstr ""
+
+#: src/preferences/pages/general.ui:229
+msgid "Unfocused Border Color"
 msgstr ""
 
 #: src/preferences/widgets/edit-shadow-window.ui:66

--- a/po/ru.po
+++ b/po/ru.po
@@ -3,8 +3,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-03-09 15:37+0000\n"
 "Last-Translator: Evgeniy Khramov <thejenjagamertjg@gmail.com>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/ru/>\n"
 "Language: ru\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -12,7 +12,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Добавить запись настроек в меню правой кнопки мыши фона"
 
@@ -64,11 +64,11 @@ msgstr "Ширина границы"
 msgid "Bottom"
 msgstr "Нижний"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Не удается добавить в список, так как он существует"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Невозможно выбрать окно с этой позиции"
 
@@ -89,28 +89,28 @@ msgstr "Пользовательский"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Настроить тень окна с закругленными углами"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Отладка"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Редактировать тени для окон с закругленными углами"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Включить"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Включить пользовательские настройки для этого окна"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Включить журнал"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Разверните этот ряд, чтобы выбрать окно."
 
@@ -168,7 +168,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Непрозрачность"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Открыть диалог сброса настроек"
 
@@ -188,7 +188,7 @@ msgstr "Выберите окно для добавления в список"
 msgid "Remove Window from this List"
 msgstr "Удалить окно из этого списка"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Сбросить настройки"
 
@@ -196,11 +196,11 @@ msgstr "Сбросить настройки"
 msgid "Right"
 msgstr "Справа"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Настройки закругленных углов..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -259,15 +259,15 @@ msgstr "Эта настройка будет пытаться воздейств
 msgid "Top"
 msgstr "Вверх"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Попробовать добавить закругленные углы в Kitty Terminal в Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Настроить отступы зажимов для терминала Kitty Terminal"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Твики"
 
@@ -278,6 +278,11 @@ msgstr "Неактивное окно"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Стиль тени неактивного окна"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Цвет границы"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/tr.po
+++ b/po/tr.po
@@ -3,15 +3,15 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-05-14 22:51+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
-"Language-Team: Turkish <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/tr/>\n"
+"Language-Team: Turkish <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/tr/>\n"
 "Language: tr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Arka Plan'ın sağ tıklama menüsüne Ayarlar Girdisi Ekle"
 
@@ -64,11 +64,11 @@ msgstr "Kenarlık Genişliği"
 msgid "Bottom"
 msgstr "Alt"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Listeye eklenemiyor, çünkü var"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Bu konumdan bir pencere seçilemez"
 
@@ -89,28 +89,28 @@ msgstr "Özel"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Yuvarlak köşeli pencerenin gölgesini özelleştir"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Hata Ayıkla"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Yuvarlak Köşeli Pencereler İçin Gölgeyi Düzenle"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Bu pencere için özel ayarları etkinleştir"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Günlüğü Etkinleştir"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Bir pencere seçmek için bu sırayı genişlet."
 
@@ -168,7 +168,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Matlık"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Tercihleri Sıfırla İletişim Kutusunu Aç"
 
@@ -188,7 +188,7 @@ msgstr "Listeye eklemek için Pencere seçin"
 msgid "Remove Window from this List"
 msgstr "Pencereyi bu listeden kaldır"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Tercihleri Sıfırla"
 
@@ -196,11 +196,11 @@ msgstr "Tercihleri Sıfırla"
 msgid "Right"
 msgstr "Sağ"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Yuvarlatılmış Köşe Ayarları..."
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -259,15 +259,15 @@ msgstr "Bu ayarlar tüm pencereleri etkilemeye çalışacaktır"
 msgid "Top"
 msgstr "Üst"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Wayland'da Kitty Terminal'e yuvarlatılmış köşeler eklemeye çalış"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Kitty Terminal için kırpma dolgularını ayarla"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "İnce Ayarlar"
 
@@ -278,6 +278,11 @@ msgstr "Odaklanmamış Pencere"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Odaklanmamış Pencere Gölge Biçemi"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Kenarlık Rengi"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/uk.po
+++ b/po/uk.po
@@ -4,8 +4,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: yilozt@outlook.com\n"
 "PO-Revision-Date: 2023-03-27 22:37+0000\n"
 "Last-Translator: Dan <denqwerta@gmail.com>\n"
-"Language-Team: Ukrainian <https://hosted.weblate.org/projects/"
-"rounded-window-corners/rounded-window-corners/uk/>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/rounded-window-"
+"corners/rounded-window-corners/uk/>\n"
 "Language: uk\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,18 +13,18 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.17-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Додати запис налаштувань у меню фону правою кнопкою миші"
 
-#: src/preferences/pages/blacklist.ui:38
-#: src/preferences/pages/custom.ui:38
+#: src/preferences/pages/blacklist.ui:38 src/preferences/pages/custom.ui:38
 msgid "Add Window"
 msgstr "Додати вікно"
 
 #: src/preferences/widgets/rounded-corners-item.ui:130
 msgid "Always keep rounded corners when window is fullscreen."
-msgstr "Завжди зберігати заокруглені кути, коли вікно розгорнуто на весь екран."
+msgstr ""
+"Завжди зберігати заокруглені кути, коли вікно розгорнуто на весь екран."
 
 #: src/preferences/widgets/rounded-corners-item.ui:93
 msgid "Always keep rounded corners when window is maximized or tiled."
@@ -67,12 +67,11 @@ msgstr "Ширина рамки"
 msgid "Bottom"
 msgstr "Низ"
 
-#: src/preferences/pages/blacklist.ts:65
-#: src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "Не можна додати до списку, тому що він вже існує"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "Не можу вибрати вікно з цієї позиції"
 
@@ -93,28 +92,28 @@ msgstr "Власний"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Налаштувати тінь заокругленого кутового вікна"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "Налагодження"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "Редагувати тіні для вікон із заокругленими кутами"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "Увімкнути"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "Увімкнути власні налаштування для цього вікна"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "Увімкнути журнал"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "Розгорніть цей рядок, щоб вибрати вікно."
 
@@ -156,9 +155,11 @@ msgstr "Ліворуч"
 
 #: src/preferences/pages/blacklist.ui:14
 msgid ""
-"Not all application can works well with rounded corners effects, add them to this list to disable effects.\n"
+"Not all application can works well with rounded corners effects, add them to "
+"this list to disable effects.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Не всі застосунки можуть добре працювати з ефектами заокруглених кутів, "
 "додайте їх до цього списку, щоб вимкнути ефекти.\n"
@@ -170,7 +171,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "Непрозорість"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "Відкрити діалогове вікно скидання налаштувань"
 
@@ -190,7 +191,7 @@ msgstr "Виберіть вікно, щоб додати до списку"
 msgid "Remove Window from this List"
 msgstr "Видалити вікно з цього списку"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "Скинути налаштування"
 
@@ -198,12 +199,14 @@ msgstr "Скинути налаштування"
 msgid "Right"
 msgstr "Праворуч"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "Налаштування заокруглених кутів..."
 
-#: src/preferences/pages/general.ui:336
-msgid "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the log"
+#: src/preferences/pages/general.ui:364
+msgid ""
+"Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
+"log"
 msgstr ""
 "Запустіть <i>journalctl -o cat -f /usr/bin/gnome-shell</i> у терміналі, щоб "
 "переглянути журнал"
@@ -220,7 +223,8 @@ msgstr "Виберіть елементи для скидання"
 msgid ""
 "Setup different clip padding by add window into this list.\n"
 "\n"
-"The item of list is instance part of WM_CLASS property with window. You can pick a window to add it into this list."
+"The item of list is instance part of WM_CLASS property with window. You can "
+"pick a window to add it into this list."
 msgstr ""
 "Налаштуйте інший відступ кліпу, додавши вікно до цього списку.\n"
 "\n"
@@ -238,7 +242,9 @@ msgid "Skip LibHandy Applications"
 msgstr "Пропустити застосунки LibHandy"
 
 #: src/preferences/pages/general.ui:23
-msgid "Some applications written using LibAdwaita or LibHandy already have native rounded corners, so we can skip them through these settings"
+msgid ""
+"Some applications written using LibAdwaita or LibHandy already have native "
+"rounded corners, so we can skip them through these settings"
 msgstr ""
 "Деякі застосунки, написані за допомогою LibAdwaita або LibHandy, вже мають "
 "власні заокруглені кути, тому ми можемо пропустити їх за допомогою цих "
@@ -256,15 +262,15 @@ msgstr "Ці налаштування намагатимуться вплину�
 msgid "Top"
 msgstr "Вверх"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Спробувати додати заокруглені кути до терміналу Kitty у Wayland"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Налаштувати внутрішній відступ для терміналу Kitty"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "Твіки"
 
@@ -275,6 +281,11 @@ msgstr "Розфокусувати вікно"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "Стиль тіні розфокусованого вікна"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "Колір рамки"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -11,7 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: src/preferences/pages/general.ui:284
+#: src/preferences/pages/general.ui:312
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "将首选项入口添加到桌面背景的右键菜单"
 
@@ -62,11 +62,11 @@ msgstr "边框大小"
 msgid "Bottom"
 msgstr "下边距"
 
-#: src/preferences/pages/blacklist.ts:65 src/preferences/pages/custom.ts:177
+#: src/preferences/pages/blacklist.ts:64 src/preferences/pages/custom.ts:174
 msgid "Can't add to list, because it has exists"
 msgstr "已在列表中，无法添加"
 
-#: src/preferences/widgets/app_row.ts:106
+#: src/preferences/widgets/app_row.ts:105
 msgid "Can't pick a window window from this position"
 msgstr "无法从此位置选取窗口"
 
@@ -87,28 +87,28 @@ msgstr "自定义"
 msgid "Customize the shadow of the rounded corner window"
 msgstr "设置圆角窗口的阴影"
 
-#: src/preferences/pages/general.ui:304
+#: src/preferences/pages/general.ui:332
 msgid "Debug"
 msgstr "调试"
 
-#: src/preferences/widgets/edit_shadow_window.ts:58
+#: src/preferences/widgets/edit_shadow_window.ts:59
 msgid "Edit Shadow for Rounded Corners Windows"
 msgstr "编辑圆角窗口阴影"
 
-#: src/preferences/pages/custom.ts:189
+#: src/preferences/pages/custom.ts:186
 msgid "Enable"
 msgstr "启用"
 
-#: src/preferences/pages/custom.ts:193
+#: src/preferences/pages/custom.ts:190
 msgid "Enable custom settings for this window"
 msgstr "为窗口启用自定义的配置"
 
-#: src/preferences/pages/general.ui:329
+#: src/preferences/pages/general.ui:357
 #: src/preferences/widgets/reset_dialog.ts:66
 msgid "Enable Log"
 msgstr "启用日志"
 
-#: src/utils/constants.ts:17
+#: src/utils/prefs.ts:48
 msgid "Expand this row to pick a window."
 msgstr "展开此控件以选取窗口。"
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Opacity"
 msgstr "透明度"
 
-#: src/preferences/pages/general.ui:367
+#: src/preferences/pages/general.ui:395
 msgid "Open Reset Preferences Dialog"
 msgstr "打开重置对话框"
 
@@ -185,7 +185,7 @@ msgstr "选取窗口"
 msgid "Remove Window from this List"
 msgstr "从列表移除"
 
-#: src/preferences/pages/general.ui:359
+#: src/preferences/pages/general.ui:387
 msgid "Reset Preferences"
 msgstr "重置设置"
 
@@ -193,11 +193,11 @@ msgstr "重置设置"
 msgid "Right"
 msgstr "右边距"
 
-#: src/utils/constants.ts:21
+#: src/utils/ui.ts:103 src/utils/ui.ts:132
 msgid "Rounded Corners Settings..."
 msgstr "圆角设置…"
 
-#: src/preferences/pages/general.ui:336
+#: src/preferences/pages/general.ui:364
 msgid ""
 "Run <i>journalctl -o cat -f /usr/bin/gnome-shell</i> in terminal to see the "
 "log"
@@ -253,15 +253,15 @@ msgstr "这里的设置将影响所有窗口"
 msgid "Top"
 msgstr "上边距"
 
-#: src/preferences/pages/general.ui:247
+#: src/preferences/pages/general.ui:275
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "在 Wayland 下为 Kitty 终端添加圆角效果"
 
-#: src/preferences/pages/general.ui:254
+#: src/preferences/pages/general.ui:282
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "调整 Kitty 终端的剪裁半径"
 
-#: src/preferences/pages/general.ui:222
+#: src/preferences/pages/general.ui:250
 msgid "Tweaks"
 msgstr "调整"
 
@@ -272,6 +272,11 @@ msgstr "未获取焦点的窗口"
 #: src/preferences/widgets/reset_dialog.ts:63
 msgid "Unfocus Window Shadow Style"
 msgstr "未获取焦点窗口阴影"
+
+#: src/preferences/pages/general.ui:229
+#, fuzzy
+msgid "Unfocused Border Color"
+msgstr "边框颜色"
 
 #: src/preferences/widgets/edit-shadow-window.ui:66
 msgid "Vertical Offset"

--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -2,7 +2,7 @@
   "name": "Rounded Window Corners",
   "description": "Add rounded corners for all windows",
   "uuid": "rounded-window-corners@yilozt",
-  "version": "12",
+  "version": "12.1",
   "url": "https://github.com/yilozt/rounded-window-corners",
   "gettext-domain": "rounded-window-corners@yilozt",
   "settings-schema": "org.gnome.shell.extensions.rounded-window-corners",

--- a/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.rounded-window-corners.gschema.xml
@@ -38,6 +38,11 @@
       <summary>Border color for rounded corners window</summary>
       <default>(0.5, 0.5, 0.5, 1.0)</default>
     </key>
+
+    <key name="unfocused-border-color" type="(dddd)">
+      <summary>Border color for rounded corners unfocused window</summary>
+      <default>(0.5, 0.5, 0.5, 1.0)</default>
+    </key>
     
     <key name="global-rounded-corner-settings" type="a{sv}">
       <summary>Global rounded corners settings for all windows</summary>

--- a/src/manager/rounded_corners_manager.ts
+++ b/src/manager/rounded_corners_manager.ts
@@ -181,6 +181,10 @@ export class RoundedCornersManager implements EffectManager {
     // Cache the offset, so that we can calculate this value once
     const content_offset_of_win = UI.computeWindowContentsOffset (win)
 
+    const col = win.appears_focused
+      ? settings ().border_color
+      : settings ().unfocused_border_color
+
     // When size changed. update uniforms for window
     effect.update_uniforms (
       UI.WindowScaleFactor (win),
@@ -188,7 +192,7 @@ export class RoundedCornersManager implements EffectManager {
       this._compute_bounds (actor, content_offset_of_win),
       {
         width: settings ().border_width,
-        color: settings ().border_color,
+        color: col,
       }
     )
 
@@ -209,6 +213,26 @@ export class RoundedCornersManager implements EffectManager {
   on_focus_changed (actor: ExtensionsWindowActor): void {
     const win = actor.meta_window
     const shadow = actor.__rwc_rounded_window_info?.shadow
+
+    const effect = this._actor_to_rounded (actor)?.get_effect (
+      constants.ROUNDED_CORNERS_EFFECT
+    ) as RoundedCornersEffectType | null
+    if (!effect) return
+    const cfg = this._get_rounded_corners_cfg (win)
+    const content_offset_of_win = UI.computeWindowContentsOffset (win)
+    const col = win.appears_focused
+      ? settings ().border_color
+      : settings ().unfocused_border_color
+    effect.update_uniforms (
+      UI.WindowScaleFactor (win),
+      cfg,
+      this._compute_bounds (actor, content_offset_of_win),
+      {
+        width: settings ().border_width,
+        color: col,
+      }
+    )
+
     if (!shadow) {
       return
     }

--- a/src/preferences/pages/general.ts
+++ b/src/preferences/pages/general.ts
@@ -33,6 +33,7 @@ export const General = GObject.registerClass (
       'preferences_entry_switch',
       'border_width_ajustment',
       'border_color_button',
+      'unfocused_border_color_button',
       'edit_shadow_row',
       'applications_group',
       'reset_preferences_btn',
@@ -48,6 +49,7 @@ export const General = GObject.registerClass (
     private _preferences_entry_switch!: Gtk.Switch
     private _border_width_ajustment!: Gtk.Adjustment
     private _border_color_button!: Gtk.ColorButton
+    private _unfocused_border_color_button!: Gtk.ColorButton
     private _edit_shadow_row!: Gtk.ListBoxRow
     private _applications_group!: Gtk.ListBox
     private _reset_preferences_btn!: Gtk.Button
@@ -114,6 +116,13 @@ export const General = GObject.registerClass (
         blue: color[2],
         alpha: color[3],
       })
+      const u_color = settings ().unfocused_border_color
+      this._unfocused_border_color_button.rgba = new Gdk.RGBA ({
+        red: u_color[0],
+        green: u_color[1],
+        blue: u_color[2],
+        alpha: u_color[3],
+      })
 
       const c = connections.get ()
       c.connect (
@@ -122,6 +131,19 @@ export const General = GObject.registerClass (
         (btn: Gtk.ColorButton) => {
           const color = btn.get_rgba ()
           settings ().border_color = [
+            color.red,
+            color.green,
+            color.blue,
+            color.alpha,
+          ]
+        }
+      )
+      c.connect (
+        this._unfocused_border_color_button,
+        'color-set',
+        (btn: Gtk.ColorButton) => {
+          const color = btn.get_rgba ()
+          settings ().unfocused_border_color = [
             color.red,
             color.green,
             color.blue,
@@ -190,6 +212,17 @@ export const General = GObject.registerClass (
         {
           const color = settings ().border_color
           this._border_color_button.rgba = new Gdk.RGBA ({
+            red: color[0],
+            green: color[1],
+            blue: color[2],
+            alpha: color[3],
+          })
+        }
+        break
+      case 'unfocused-border-color':
+        {
+          const color = settings ().unfocused_border_color
+          this._unfocused_border_color_button.rgba = new Gdk.RGBA ({
             red: color[0],
             green: color[1],
             blue: color[2],

--- a/src/preferences/pages/general.ui
+++ b/src/preferences/pages/general.ui
@@ -214,6 +214,34 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkListBoxRow">
+            <child>
+              <object class="GtkBox">
+                <child>
+                  <object class="GtkBox">
+                    <property name="valign">center</property>
+                    <property name="hexpand">true</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Unfocused Border Color</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkColorButton" id="unfocused_border_color_button">
+                    <property name="visible">true</property>
+                    <property name="valign">center</property>
+                    <property name="use-alpha">true</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -33,6 +33,7 @@ export type SchemasKeys =
   | 'debug-mode'
   | 'border-width'
   | 'border-color'
+  | 'unfocused-border-color'
   | 'settings-version'
   | 'tweak-kitty-terminal'
   | 'enable-preferences-entry'
@@ -56,6 +57,7 @@ export class Settings {
   border_width!: number
   settings_version!: number
   border_color!: [number, number, number, number]
+  unfocused_border_color!: [number, number, number, number]
 
   /** GSettings, which used to store and load settings */
   g_settings: Gio.Settings


### PR DESCRIPTION
Added functionality to have a secondary border colour for unfocused windows

Gonna be honest here - this was a project in frankensteining unfamiliar code in an unfamiliar language with an unfamiliar API, so while it works on my machine just fine, it could probably do with a look over and refactor if necessary, cuz once I figured out where to put the required logic, I just grabbed the uniform update function from elsewhere and plugged it in.